### PR TITLE
Mapping

### DIFF
--- a/app/logic/mapping.py
+++ b/app/logic/mapping.py
@@ -1,5 +1,8 @@
+import re, math
 from enum import Enum, IntEnum
-						  
+from pyproj import Transformer
+from typing import List
+
 class Datum(Enum):
 	WGS84 = 1
 	NAD27 = 2  # NAD27 CONUS
@@ -14,6 +17,7 @@ class CoordFormat(IntEnum):
 	DEG = 3     # D.d
 	DEGMIN = 4  # DM.m
 	DMS = 5     # DMS.s
+	DEGLIST = 6 # [D.d,D.d] (the only one that's not a string)
 
 	@classmethod
 	def possibleValues(cls) -> str:
@@ -26,3 +30,135 @@ class CoordFormat(IntEnum):
 	def displayName(self) -> str:
 		return CoordFormat.displayNames()[self]
 
+	def isUTM(self) -> bool:
+		return self in [CoordFormat.UTM5, CoordFormat.UTM7]
+
+
+class DecimalDegrees():
+	"""
+	Base representation of a point on the globe. 
+
+	Initializtion method #1:
+		dd = DecimalDegrees(-118.0,45.0) # if the decimal degrees are already known
+
+	Initializtion method #2:
+		dd = DecimalDegrees()
+		dd.fromNMEA(<NMEA>) # where <NMEA> is a list of 4 strings (which will be converted to degrees decimal)
+
+	#TODO Initializtion method #3: From UTM
+
+	"""
+	latDd: float
+	lonDd: float
+	transformer: Transformer
+	sourceCRS: int = 0
+	targetCRS: int = 0
+
+	def __init__(self, lat: float = 0.0, lon: float = 0.0):
+		self.latDd = lat
+		self.lonDd = lon
+
+	def fromNMEA(self, coords: List[str]):
+		"""coords must be a parsed list of location data from fleetsync in NMEA format"""
+		assert len(coords) == 4 
+		assert coords[1] in ["N", "S"]
+		assert coords[3] in ["E", "W"]
+
+		latDeg = int(coords[0][0:2])  # first two numbers are degrees
+		latMin = float(coords[0][2:])  # remainder is minutes
+		lonDeg = int(coords[2][0:3])  # first three numbers are degrees
+		lonMin = float(coords[2][3:])  # remainder is minutes
+		# add decimal portion of degrees here, before changing sign for hemisphere
+		self.latDd = latDeg+latMin/60
+		self.lonDd = lonDeg+lonMin/60
+		if coords[1] == "S":
+			self.latDd = -self.latDd
+		if coords[3] == "W":
+			self.lonDd = -self.lonDd
+
+	def utmZone(self) -> int:
+		return  math.floor((self.lonDd+180)/6)+1
+
+	def __estabishTransformer(self, targetDatum: Datum, targetFormat: CoordFormat):
+		# relevant CRSes:
+		#  4326 = WGS84 lat/lon
+		#  4267 = NAD27 CONUS lat/lon
+		#  32600+zone = WGS84 UTM (e.g. 32610 = UTM zone 10)
+		#  26700+zone = NAD27 CONUS UTM (e.g. 26710 = UTM zone 10)
+
+		# if target datum is WGS84 and target format is anything other than UTM, just do the math
+
+		if targetDatum != Datum.WGS84 or (targetFormat.isUTM()):
+			sourceCRS = 4326
+			if targetDatum == Datum.WGS84:
+				targetCRS = 32600+self.utmZone()
+			elif targetDatum == Datum.NAD27:
+				if targetFormat.isUTM:
+					targetCRS = 26700+self.utmZone()
+				else:
+					targetCRS = 4267
+			else:
+				targetCRS = sourceCRS  # fallback to do a pass-thru transformation
+
+			# If the source and target CRS's haven't changed, then just re-use the same tranformer from last time
+			if sourceCRS != self.sourceCRS or targetCRS != self.targetCRS:
+				self.sourceCRS = sourceCRS
+				self.targetCRS = targetCRS
+				self.transformer = Transformer.from_crs(sourceCRS, targetCRS)
+
+	def toAlternateFormat(self, targetDatum: Datum, targetFormat: CoordFormat):
+		easting = 0
+		northing = 0
+
+		self.__estabishTransformer(targetDatum, targetFormat)
+
+		t = self.transformer.transform(self.latDd, self.lonDd)
+
+		if targetFormat.isUTM():
+			[easting, northing] = map(int, t)
+		else:
+			# TODO Are we sure this isn't backwards?
+			[lonDd, latDd] = t 
+			# Also, why are we bothering to convert from Dd back to Dd? 
+
+		latDd = float(latDd)
+		latDeg = int(latDd)
+		latMin = float((latDd-float(latDeg))*60.0)
+		latSec = float((latMin-int(latMin))*60.0)
+		lonDd = float(lonDd)
+		lonLetter = "E"
+		if lonDd < 0 and targetFormat != CoordFormat.DEGLIST:  # leave it negative for D.dList
+			lonDd = -lonDd
+			lonLetter = "W"
+		lonDeg = int(lonDd)
+		lonMin = float((abs(lonDd)-float(abs(lonDeg)))*60.0)
+		lonSec = float((abs(lonMin)-int(abs(lonMin)))*60.0)
+		# LOG.debug("lonDd="+str(lonDd))
+		# LOG.debug("lonDeg="+str(lonDeg))
+
+		# return the requested format
+		# desired accuracy / digits of precision:
+		# at 39 degrees north,
+		# 0.00001 degree latitude = 1.11 meters
+		# 0.001 minute latutude = 1.85 meters
+		# 0.1 second latitude = 3.08 meters
+		# (longitude lengths are about 78% as much as latitude, at 39 degrees north)
+		if targetFormat == CoordFormat.DEGLIST:
+			return [latDd, lonDd]
+
+		if targetFormat == CoordFormat.DEG:
+			return "{:.6f}°N  {:.6f}°{}".format(latDd, lonDd, lonLetter)
+
+		if targetFormat == CoordFormat.DEGMIN:
+			return "{}° {:.4f}'N  {}° {:.4f}'{}".format(latDeg, latMin, abs(lonDeg), lonMin, lonLetter)
+
+		if targetFormat == CoordFormat.DMS:
+			return "{}° {}' {:.2f}\"N  {}° {}' {:.2f}\"{}".format(latDeg, int(latMin), latSec, abs(lonDeg), int(lonMin), lonSec, lonLetter)
+
+		eStr = "{0:07d}".format(easting)
+		nStr = "{0:07d}".format(northing)
+		if targetFormat == CoordFormat.UTM7:
+			return "{} {}   {} {}".format(eStr[0:2], eStr[2:], nStr[0:2], nStr[2:])
+
+		if targetFormat == CoordFormat.UTM5:
+			return "{}  {}".format(eStr[2:], nStr[2:])

--- a/app/logic/mapping.py
+++ b/app/logic/mapping.py
@@ -2,16 +2,23 @@ import re, math
 from enum import Enum, IntEnum
 from pyproj import Transformer
 from typing import List
+from utility.logging_helpers import getLogger
+
+LOG = getLogger()
+
+NMEACoords = List[str]
 
 class Datum(Enum):
+	"""Enumeration of the Datum types we can handle."""
 	WGS84 = 1
-	NAD27 = 2  # NAD27 CONUS
+	NAD27 = 2  # same as NAD27 CONUS
 
 	@classmethod
 	def possibleValues(cls) -> str:
 		return ", ".join([e.name for e in cls])
 
 class CoordFormat(IntEnum):
+	"""Enumeration of the styles of coordinate formats we can process."""
 	UTM7 = 1    # UTM 7x7
 	UTM5 = 2    # UTM 5x5
 	DEG = 3     # D.d
@@ -25,7 +32,7 @@ class CoordFormat(IntEnum):
 
 	@classmethod
 	def displayNames(cls):
-		return {cls.UTM7: "UTM 7x7", cls.UTM5: "UTM 5x5", cls.DEG: "D.d°", cls.DEGMIN: "D° M.m'", cls.DMS: "D° M' S.s\""}
+		return {cls.UTM7: "UTM 7x7", cls.UTM5: "UTM 5x5", cls.DEG: "D.d°", cls.DEGMIN: "D° M.m'", cls.DMS: "D° M' S.s\"", cls.DEGLIST: "(Python list)"}
 	
 	def displayName(self) -> str:
 		return CoordFormat.displayNames()[self]
@@ -33,110 +40,184 @@ class CoordFormat(IntEnum):
 	def isUTM(self) -> bool:
 		return self in [CoordFormat.UTM5, CoordFormat.UTM7]
 
+class CRSCode(Enum):
+	"""Enumeration of the Coordinate Reference Systems (CRS) we can process."""
+	WGS84_LATLON = 4326  # based on the Earth's center of mass, used by the GPS among others.
+	WGS84_UTM = 32600  # (add the UTM zone)
+	NAD27_CONUS_LATLON = 4267
+	NAD27_CONUS_UTM = 26700 # (add the UTM zone)
+	# WEB_MERCATOR = 3857 # e.g. Google Maps and OpenStreetMap
+
+	@classmethod
+	def possibleValues(cls) -> str:
+		return ", ".join([e.name for e in cls])
+
+	@classmethod
+	def perDatumAndFormat(cls, datum: Datum, coordFormat: CoordFormat):
+		if datum == Datum.WGS84:
+			return CRSCode.WGS84_UTM if coordFormat.isUTM() else CRSCode.WGS84_LATLON
+		if datum == Datum.NAD27:
+			return CRSCode.NAD27_CONUS_UTM if coordFormat.isUTM() else CRSCode.NAD27_CONUS_LATLON
+		raise AttributeError("Unable to determine a CRSCode form the given combination of datum/format.")
+
+	def isUTM(self) -> bool:
+		return self in [CRSCode.WGS84_UTM, CRSCode.NAD27_CONUS_UTM]
+
 
 class DecimalDegrees():
 	"""
-	Base representation of a point on the globe. 
+	Our internal representation of a point on the globe, along with various conversion methods. 
 
-	Initializtion method #1:
-		dd = DecimalDegrees(-118.0,45.0) # if the decimal degrees are already known
+	Fields:
+		datum -- the notation system for these coordinates
+		latDd -- the lattitude in degress decimal (negative for south)
+		lonDd -- the lattitude in degress decimal (negative for west)
+		origDatum, origLatDd, origLonDd -- saved copies of the fields as they were first initialized
 
-	Initializtion method #2:
-		dd = DecimalDegrees()
-		dd.fromNMEA(<NMEA>) # where <NMEA> is a list of 4 strings (which will be converted to degrees decimal)
-
-	#TODO Initializtion method #3: From UTM
+	Initialization:
+		dd = DecimalDegrees(lat = -118.0, lon = 45.0) # if the decimal degrees are already known
+	or
+		dd = DecimalDegrees.fromNMEA(nmea = ['3918.9200', 'N', '11955.2100', 'W'])
+	or
+		#TODO Initializtion method #3: From UTM
 
 	"""
-	latDd: float
+	datum: Datum = Datum.WGS84
+	latDd: float 
 	lonDd: float
+	origDatum: Datum
+	origLatDd: float
+	origLonDd: float
 	transformer: Transformer
-	sourceCRS: int = 0
-	targetCRS: int = 0
+	lastSourceCRS: int = 0
+	lastTargetCRS: int = 0
 
-	def __init__(self, lat: float = 0.0, lon: float = 0.0):
-		self.latDd = lat
-		self.lonDd = lon
+	def __init__(self, lat: float = 0.0, lon: float = 0.0, datum: Datum = Datum.WGS84):
+		self.origLatDd = self.latDd = lat
+		self.origLonDd = self.lonDd = lon
+		self.origDatum = self.datum = datum
 
-	def fromNMEA(self, coords: List[str]):
-		"""coords must be a parsed list of location data from fleetsync in NMEA format"""
-		assert len(coords) == 4 
-		assert coords[1] in ["N", "S"]
-		assert coords[3] in ["E", "W"]
+	@classmethod
+	def validateNMEACoords(cls, nmea: NMEACoords):
+		"""NMEA coords must be a parsed list of location data from fleetsync in NMEA format"""
+		isValid = (len(nmea) == 4 and nmea[1] in ["N", "S"] and nmea[3] in ["E", "W"])
+		# TODO also validate that nmea[0 and 2] are all digits
+		if (not isValid):
+			raise AttributeError("Invalid NMEA data: {}".format(nmea))
 
+	@classmethod
+	def fromNMEA(cls, coords: NMEACoords, datum: Datum = Datum.WGS84):
+		"Initialize DecimalDegrees from NMEA coordinates"
+		cls.validateNMEACoords(coords)
 		latDeg = int(coords[0][0:2])  # first two numbers are degrees
 		latMin = float(coords[0][2:])  # remainder is minutes
 		lonDeg = int(coords[2][0:3])  # first three numbers are degrees
 		lonMin = float(coords[2][3:])  # remainder is minutes
 		# add decimal portion of degrees here, before changing sign for hemisphere
-		self.latDd = latDeg+latMin/60
-		self.lonDd = lonDeg+lonMin/60
+		latDd = latDeg+latMin/60
+		lonDd = lonDeg+lonMin/60
 		if coords[1] == "S":
-			self.latDd = -self.latDd
+			latDd = -latDd
 		if coords[3] == "W":
-			self.lonDd = -self.lonDd
+			lonDd = -lonDd
+		return cls(latDd,lonDd,datum)
 
 	def utmZone(self) -> int:
+		"""The UTM zone (according to the longitude)."""
 		return  math.floor((self.lonDd+180)/6)+1
 
-	def __estabishTransformer(self, targetDatum: Datum, targetFormat: CoordFormat):
-		# relevant CRSes:
-		#  4326 = WGS84 lat/lon
-		#  4267 = NAD27 CONUS lat/lon
-		#  32600+zone = WGS84 UTM (e.g. 32610 = UTM zone 10)
-		#  26700+zone = NAD27 CONUS UTM (e.g. 26710 = UTM zone 10)
+	def fromEPSG(self) -> int:
+		"""Curently, the source CRS is always WGS84_LATLON, since that's what the DecimalDegrees internal storage represents"""
+		return CRSCode.WGS84_LATLON.value
 
+	def toEPSG(self, targetDatum, targetFormat) -> int:
+		"""
+		Determine the target EPSG code based on specified datum and format -- and if going to UTM, then also based on
+		the UTM zone that corresponds to the original latitude.
+		"""
+		crs: CRSCode = CRSCode.perDatumAndFormat(targetDatum, targetFormat)
+		if crs.isUTM():
+			return crs.value + self.utmZone()
+		return crs.value
+
+	def __estabishTransformer(self, sourceCRS: int, targetCRS: int):
+		# Relevant Coordinate Reference Systems (CRS):
+		# EPSG:4326 = WGS84 in lat/lon -- based on the Earth's center of mass, used by the GPS among others.
+		# EPGS:4267 = NAD27 CONUS (lat/lon)
+		# EPGS:32600+zone = WGS84 in UTM (e.g. 32610 = UTM zone 10)
+		# EPGS:26700+zone = NAD27 CONUS in UTM (e.g. 26710 = UTM zone 10)
+		# FYI:
+		# EPSG:3857 = Web Mercator projection used for display by many web-based mapping tools, including Google Maps and OpenStreetMap.
+		# EPSG:7789 = International Terrestrial Reference Frame 2014 (ITRF2014), an Earth-fixed system that is independent of continental drift.[4]
 		# if target datum is WGS84 and target format is anything other than UTM, just do the math
 
-		if targetDatum != Datum.WGS84 or (targetFormat.isUTM()):
-			sourceCRS = 4326
-			if targetDatum == Datum.WGS84:
-				targetCRS = 32600+self.utmZone()
-			elif targetDatum == Datum.NAD27:
-				if targetFormat.isUTM:
-					targetCRS = 26700+self.utmZone()
-				else:
-					targetCRS = 4267
-			else:
-				targetCRS = sourceCRS  # fallback to do a pass-thru transformation
+		# If the source and target CRS's haven't changed, then just re-use the same tranformer from last time
+		if sourceCRS != self.lastSourceCRS or targetCRS != self.lastTargetCRS:
+			self.lastSourceCRS = sourceCRS
+			self.lastTargetCRS = targetCRS
+			self.transformer = Transformer.from_crs(sourceCRS, targetCRS)
 
-			# If the source and target CRS's haven't changed, then just re-use the same tranformer from last time
-			if sourceCRS != self.sourceCRS or targetCRS != self.targetCRS:
-				self.sourceCRS = sourceCRS
-				self.targetCRS = targetCRS
-				self.transformer = Transformer.from_crs(sourceCRS, targetCRS)
+	def toDEGMIN(self) -> (int, float, int, float):
+		"""
+		Converts decimal degrees to integer degrees and decimal minutes.
+		The degrees might be negative.
+		The minutes will always be positive.
+		"""
+		latDeg = int(self.latDd) # might be negative
+		latMin = round(float((abs(self.latDd)-float(abs(latDeg)))*60.0),8)
+		lonDeg = int(self.lonDd)  # might be negative
+		lonMin = round(float((abs(self.lonDd)-float(abs(lonDeg)))*60.0),8)
+		return (latDeg, latMin, lonDeg, lonMin)
+		
+	def toDMS(self) -> (int, int, float, int, int, float):
+		"""
+		Converts decimal degrees to a 6-element tuple of integer degrees, integer minutes and decimal seconds for lat and lon.
+		The degrees might be negative.
+		The minutes and seconds will always be positive.
+		"""
+		(latDeg, latMin, lonDeg, lonMin) = self.toDEGMIN()
+		latSec = round(float((latMin-int(latMin))*60.0),8)
+		lonSec = round(float((lonMin-int(lonMin))*60.0),8)
+		return (latDeg, int(latMin), latSec, lonDeg, int(lonMin), lonSec)
+
 
 	def toAlternateFormat(self, targetDatum: Datum, targetFormat: CoordFormat):
+		"""This global position (internally stored as decimal degrees) as converted to the specified format."""
 		easting = 0
 		northing = 0
 
-		self.__estabishTransformer(targetDatum, targetFormat)
+		sourceCRS = self.fromEPSG()
+		targetCRS = self.toEPSG(targetDatum, targetFormat)
+		LOG.debug("Converting from {} to {}".format(sourceCRS,targetCRS))
 
-		t = self.transformer.transform(self.latDd, self.lonDd)
+		if sourceCRS != targetCRS:
+			# a transformer is needed for all cases except simple conversions of degree representions (decimals on which part)
+			self.__estabishTransformer(sourceCRS, targetCRS)
+			t = self.transformer.transform(self.latDd, self.lonDd)
+			if targetFormat.isUTM():
+				[easting, northing] = map(int, t)
+			else:
+				# In the case of converting beteen Datums, the lat/lon will be (slightly) different
+				[latDd, lonDd] = t 
+				self.datum = targetDatum
+				self.latDd = float(latDd)
+				self.lonDd = float(lonDd)
+		
+		LOG.debug("Converted from {} {} {} to {} {} {}".format(self.origDatum.name, self.origLatDd,self.origLonDd,self.datum.name,self.latDd,self.lonDd))
 
 		if targetFormat.isUTM():
-			[easting, northing] = map(int, t)
-		else:
-			# TODO Are we sure this isn't backwards?
-			[lonDd, latDd] = t 
-			# Also, why are we bothering to convert from Dd back to Dd? 
+			eStr = "{0:07d}".format(easting)
+			nStr = "{0:07d}".format(northing)
+			if targetFormat == CoordFormat.UTM5:
+				return "{}  {}".format(eStr[2:], nStr[2:])
+			else:
+				return "{} {}  {} {}".format(eStr[0:2], eStr[2:], nStr[0:2], nStr[2:])
 
-		latDd = float(latDd)
-		latDeg = int(latDd)
-		latMin = float((latDd-float(latDeg))*60.0)
-		latSec = float((latMin-int(latMin))*60.0)
-		lonDd = float(lonDd)
-		lonLetter = "E"
-		if lonDd < 0 and targetFormat != CoordFormat.DEGLIST:  # leave it negative for D.dList
-			lonDd = -lonDd
-			lonLetter = "W"
-		lonDeg = int(lonDd)
-		lonMin = float((abs(lonDd)-float(abs(lonDeg)))*60.0)
-		lonSec = float((abs(lonMin)-int(abs(lonMin)))*60.0)
-		# LOG.debug("lonDd="+str(lonDd))
-		# LOG.debug("lonDeg="+str(lonDeg))
+		# At this point, we are either working with decimal degress as originally stored, or as converted between Datums
+		(latDeg, latMin, latSec, lonDeg, lonMin, lonSec) = self.toDMS()
+		latLetter = "N" if latDeg >= 0 else "S"
+		lonLetter = "E" if lonDeg >= 0 else "W"
 
-		# return the requested format
 		# desired accuracy / digits of precision:
 		# at 39 degrees north,
 		# 0.00001 degree latitude = 1.11 meters
@@ -144,21 +225,19 @@ class DecimalDegrees():
 		# 0.1 second latitude = 3.08 meters
 		# (longitude lengths are about 78% as much as latitude, at 39 degrees north)
 		if targetFormat == CoordFormat.DEGLIST:
-			return [latDd, lonDd]
+			return [round(self.latDd,8), round(self.lonDd,8)]
 
 		if targetFormat == CoordFormat.DEG:
-			return "{:.6f}°N  {:.6f}°{}".format(latDd, lonDd, lonLetter)
+			return "{:.6f}°{}  {:.6f}°{}".format(abs(self.latDd), latLetter, abs(self.lonDd), lonLetter)
 
 		if targetFormat == CoordFormat.DEGMIN:
-			return "{}° {:.4f}'N  {}° {:.4f}'{}".format(latDeg, latMin, abs(lonDeg), lonMin, lonLetter)
+			return "{}° {:.4f}'{}  {}° {:.4f}'{}".format(abs(latDeg), latMin, latLetter, abs(lonDeg), lonMin, lonLetter)
 
 		if targetFormat == CoordFormat.DMS:
-			return "{}° {}' {:.2f}\"N  {}° {}' {:.2f}\"{}".format(latDeg, int(latMin), latSec, abs(lonDeg), int(lonMin), lonSec, lonLetter)
+			return "{}° {}' {:.2f}\"{}  {}° {}' {:.2f}\"{}".format(abs(latDeg), int(latMin), latSec, latLetter, abs(lonDeg), int(lonMin), lonSec, lonLetter)
 
-		eStr = "{0:07d}".format(easting)
-		nStr = "{0:07d}".format(northing)
-		if targetFormat == CoordFormat.UTM7:
-			return "{} {}   {} {}".format(eStr[0:2], eStr[2:], nStr[0:2], nStr[2:])
+	def __str__(self):
+		if (self.datum.name, self.latDd, self.lonDd) == (self.origDatum.name, self.origLatDd, self.origLonDd):
+			return "{} {} {}".format(self.datum.name, self.latDd, self.lonDd)
+		return "{} {} {} (orig: {} {} {})".format(self.datum.name, self.latDd, self.lonDd, self.origDatum.name, self.origLatDd, self.origLonDd)
 
-		if targetFormat == CoordFormat.UTM5:
-			return "{}  {}".format(eStr[2:], nStr[2:])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,5 +64,5 @@ coordformat = XXX
         assert e.message == """The configuration setting of 'datum = XXX' is invalid.
 Possible values are: WGS84, NAD27
 The configuration setting of 'coordformat = XXX' is invalid.
-Possible values are: UTM7, UTM5, DEG, DEGMIN, DMS"""
+Possible values are: UTM7, UTM5, DEG, DEGMIN, DMS, DEGLIST"""
 

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,4 +1,4 @@
-from app.logic.mapping import Datum, CoordFormat, DecimalDegrees
+from app.logic.mapping import Datum, CoordFormat, DecimalDegrees, CRSCode
 import utility.logging_helpers
 
 LOG = utility.logging_helpers.getLogger()
@@ -13,14 +13,15 @@ def test_displayName():
 	assert CoordFormat.DEG.displayName() == "D.d°"
 	assert CoordFormat.DEGMIN.displayName() == "D° M.m'"
 	assert CoordFormat.DMS.displayName() == "D° M' S.s\""
+	assert CoordFormat.DEGLIST.displayName() == "(Python list)"
 
 
 def test_fromNMEA():
-	dd = DecimalDegrees()
-	def convert(coords):
-		dd.fromNMEA(coords)
+	def convert(nmea):
+		dd = DecimalDegrees.fromNMEA(nmea)
 		return (dd.latDd,dd.lonDd)
 
+	#TODO validate that these NMEA conversion tests are correct
 	assert convert(['3918.9200', 'N', '11955.2100', 'W']) == (39.315333333333335, -119.92016666666666)
 	assert convert(['3918.9200', 'N', '12055.2100', 'W']) == (39.315333333333335, -120.92016666666666)
 	assert convert(['3918.9200', 'N', '12155.2100', 'W']) == (39.315333333333335, -121.92016666666666)
@@ -105,3 +106,32 @@ def test_fromNMEA():
 	assert convert(['4000.0000', 'N', '11915.0000', 'W']) == (40.0, -119.25)
 	assert convert(['4000.0000', 'N', '11900.0000', 'W']) == (40.0, -119.0)
 
+def test_toDEGMIN():
+	assert DecimalDegrees(0, 0).toDEGMIN() == (0, 0.0, 0, 0.0)
+	assert DecimalDegrees(90, 180).toDEGMIN() == (90, 0.0, 180, 0.0)
+	assert DecimalDegrees(38.5, -121.25).toDEGMIN() == (38, 30.0, -121, 15.0)
+	assert DecimalDegrees(38.125, -121.025).toDEGMIN() == (38, 7.5, -121, 1.5)
+
+def test_toDMS():
+	assert DecimalDegrees(0, 0).toDMS() == (0, 0.0, 0.0, 0, 0.0, 0.0)
+	assert DecimalDegrees(90, 180).toDMS() == (90, 0.0, 0.0, 180, 0.0, 0.0)
+	assert DecimalDegrees(38.5, -121.25).toDMS() == (38, 30.0, 0.0, -121, 15.0, 0.0)
+	assert DecimalDegrees(38.125, -121.025).toDMS() == (38, 7, 30.0, -121, 1, 30.0)
+
+
+def test_toAlternateFormat():
+	dd = DecimalDegrees.fromNMEA(['3830.0000', 'N', '12115.0000', 'W'])
+	assert dd.toAlternateFormat(Datum.WGS84, CoordFormat.UTM5) == "52601  62744"
+	assert dd.toAlternateFormat(Datum.WGS84, CoordFormat.UTM7) == "06 52601  42 62744"
+	assert dd.toAlternateFormat(Datum.WGS84, CoordFormat.DEG) == "38.500000°N  121.250000°W"
+	assert dd.toAlternateFormat(Datum.WGS84, CoordFormat.DEGMIN) == "38° 30.0000'N  121° 15.0000'W"
+	assert dd.toAlternateFormat(Datum.WGS84, CoordFormat.DMS) == "38° 30' 0.00\"N  121° 15' 0.00\"W"
+	assert dd.toAlternateFormat(Datum.WGS84, CoordFormat.DEGLIST) == [38.5, -121.25]
+
+	#TODO FIXME These do not seem right... for one thing, they are inconsistent betweenm themselves
+	assert dd.toAlternateFormat(Datum.NAD27, CoordFormat.UTM5) == "52697  62549"
+	assert dd.toAlternateFormat(Datum.NAD27, CoordFormat.UTM7) == "06 52697  42 62549"
+	assert dd.toAlternateFormat(Datum.NAD27, CoordFormat.DEG) == "38.500092°N  121.248940°W"
+	assert dd.toAlternateFormat(Datum.NAD27, CoordFormat.DEGMIN) == "38° 30.0000'N  121° 14.0000'W"
+	assert dd.toAlternateFormat(Datum.NAD27, CoordFormat.DMS) == "38° 30' 0.99\"N  121° 14' 48.56\"W"
+	assert dd.toAlternateFormat(Datum.NAD27, CoordFormat.DEGLIST) == [38.50036714, -121.24576155]

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,12 +1,107 @@
-from app.logic.mapping import Datum, CoordFormat
+from app.logic.mapping import Datum, CoordFormat, DecimalDegrees
+import utility.logging_helpers
+
+LOG = utility.logging_helpers.getLogger()
 
 def test_possibleValues():
-    assert Datum.possibleValues() == "WGS84, NAD27"
-    assert CoordFormat.possibleValues() == "UTM7, UTM5, DEG, DEGMIN, DMS"
+	assert Datum.possibleValues() == "WGS84, NAD27"
+	assert CoordFormat.possibleValues() == "UTM7, UTM5, DEG, DEGMIN, DMS, DEGLIST"
 
 def test_displayName():
-    assert CoordFormat.UTM7.displayName() == "UTM 7x7"
-    assert CoordFormat.UTM5.displayName() == "UTM 5x5"
-    assert CoordFormat.DEG.displayName() == "D.d°"
-    assert CoordFormat.DEGMIN.displayName() == "D° M.m'"
-    assert CoordFormat.DMS.displayName() == "D° M' S.s\""
+	assert CoordFormat.UTM7.displayName() == "UTM 7x7"
+	assert CoordFormat.UTM5.displayName() == "UTM 5x5"
+	assert CoordFormat.DEG.displayName() == "D.d°"
+	assert CoordFormat.DEGMIN.displayName() == "D° M.m'"
+	assert CoordFormat.DMS.displayName() == "D° M' S.s\""
+
+
+def test_fromNMEA():
+	dd = DecimalDegrees()
+	def convert(coords):
+		dd.fromNMEA(coords)
+		return (dd.latDd,dd.lonDd)
+
+	assert convert(['3918.9200', 'N', '11955.2100', 'W']) == (39.315333333333335, -119.92016666666666)
+	assert convert(['3918.9200', 'N', '12055.2100', 'W']) == (39.315333333333335, -120.92016666666666)
+	assert convert(['3918.9200', 'N', '12155.2100', 'W']) == (39.315333333333335, -121.92016666666666)
+	assert convert(['3918.9200', 'N', '11959.9900', 'W']) == (39.315333333333335, -119.99983333333333)
+	assert convert(['3918.9200', 'N', '12000.0000', 'W']) == (39.315333333333335, -120.0)
+	assert convert(['3918.9200', 'N', '12000.0100', 'W']) == (39.315333333333335, -120.00016666666667)
+	assert convert(['3830.0000', 'N', '12130.0000', 'W']) == (38.5, -121.5)
+	assert convert(['3830.0000', 'N', '12115.0000', 'W']) == (38.5, -121.25)
+	assert convert(['3830.0000', 'N', '12100.0000', 'W']) == (38.5, -121.0)
+	assert convert(['3830.0000', 'N', '12045.0000', 'W']) == (38.5, -120.75)
+	assert convert(['3830.0000', 'N', '12030.0000', 'W']) == (38.5, -120.5)
+	assert convert(['3830.0000', 'N', '12015.0000', 'W']) == (38.5, -120.25)
+	assert convert(['3830.0000', 'N', '12000.0000', 'W']) == (38.5, -120.0)
+	assert convert(['3830.0000', 'N', '11945.0000', 'W']) == (38.5, -119.75)
+	assert convert(['3830.0000', 'N', '11930.0000', 'W']) == (38.5, -119.5)
+	assert convert(['3830.0000', 'N', '11915.0000', 'W']) == (38.5, -119.25)
+	assert convert(['3830.0000', 'N', '11900.0000', 'W']) == (38.5, -119.0)
+	assert convert(['3845.0000', 'N', '12130.0000', 'W']) == (38.75, -121.5)
+	assert convert(['3845.0000', 'N', '12115.0000', 'W']) == (38.75, -121.25)
+	assert convert(['3845.0000', 'N', '12100.0000', 'W']) == (38.75, -121.0)
+	assert convert(['3845.0000', 'N', '12045.0000', 'W']) == (38.75, -120.75)
+	assert convert(['3845.0000', 'N', '12030.0000', 'W']) == (38.75, -120.5)
+	assert convert(['3845.0000', 'N', '12015.0000', 'W']) == (38.75, -120.25)
+	assert convert(['3845.0000', 'N', '12000.0000', 'W']) == (38.75, -120.0)
+	assert convert(['3845.0000', 'N', '11945.0000', 'W']) == (38.75, -119.75)
+	assert convert(['3845.0000', 'N', '11930.0000', 'W']) == (38.75, -119.5)
+	assert convert(['3845.0000', 'N', '11915.0000', 'W']) == (38.75, -119.25)
+	assert convert(['3845.0000', 'N', '11900.0000', 'W']) == (38.75, -119.0)
+	assert convert(['3900.0000', 'N', '12130.0000', 'W']) == (39.0, -121.5)
+	assert convert(['3900.0000', 'N', '12115.0000', 'W']) == (39.0, -121.25)
+	assert convert(['3900.0000', 'N', '12100.0000', 'W']) == (39.0, -121.0)
+	assert convert(['3900.0000', 'N', '12045.0000', 'W']) == (39.0, -120.75)
+	assert convert(['3900.0000', 'N', '12030.0000', 'W']) == (39.0, -120.5)
+	assert convert(['3900.0000', 'N', '12015.0000', 'W']) == (39.0, -120.25)
+	assert convert(['3900.0000', 'N', '12000.0000', 'W']) == (39.0, -120.0)
+	assert convert(['3900.0000', 'N', '11945.0000', 'W']) == (39.0, -119.75)
+	assert convert(['3900.0000', 'N', '11930.0000', 'W']) == (39.0, -119.5)
+	assert convert(['3900.0000', 'N', '11915.0000', 'W']) == (39.0, -119.25)
+	assert convert(['3900.0000', 'N', '11900.0000', 'W']) == (39.0, -119.0)
+	assert convert(['3915.0000', 'N', '12130.0000', 'W']) == (39.25, -121.5)
+	assert convert(['3915.0000', 'N', '12115.0000', 'W']) == (39.25, -121.25)
+	assert convert(['3915.0000', 'N', '12100.0000', 'W']) == (39.25, -121.0)
+	assert convert(['3915.0000', 'N', '12045.0000', 'W']) == (39.25, -120.75)
+	assert convert(['3915.0000', 'N', '12030.0000', 'W']) == (39.25, -120.5)
+	assert convert(['3915.0000', 'N', '12015.0000', 'W']) == (39.25, -120.25)
+	assert convert(['3915.0000', 'N', '12000.0000', 'W']) == (39.25, -120.0)
+	assert convert(['3915.0000', 'N', '11945.0000', 'W']) == (39.25, -119.75)
+	assert convert(['3915.0000', 'N', '11930.0000', 'W']) == (39.25, -119.5)
+	assert convert(['3915.0000', 'N', '11915.0000', 'W']) == (39.25, -119.25)
+	assert convert(['3915.0000', 'N', '11900.0000', 'W']) == (39.25, -119.0)
+	assert convert(['3930.0000', 'N', '12130.0000', 'W']) == (39.5, -121.5)
+	assert convert(['3930.0000', 'N', '12115.0000', 'W']) == (39.5, -121.25)
+	assert convert(['3930.0000', 'N', '12100.0000', 'W']) == (39.5, -121.0)
+	assert convert(['3930.0000', 'N', '12045.0000', 'W']) == (39.5, -120.75)
+	assert convert(['3930.0000', 'N', '12030.0000', 'W']) == (39.5, -120.5)
+	assert convert(['3930.0000', 'N', '12015.0000', 'W']) == (39.5, -120.25)
+	assert convert(['3930.0000', 'N', '12000.0000', 'W']) == (39.5, -120.0)
+	assert convert(['3930.0000', 'N', '11945.0000', 'W']) == (39.5, -119.75)
+	assert convert(['3930.0000', 'N', '11930.0000', 'W']) == (39.5, -119.5)
+	assert convert(['3930.0000', 'N', '11915.0000', 'W']) == (39.5, -119.25)
+	assert convert(['3930.0000', 'N', '11900.0000', 'W']) == (39.5, -119.0)
+	assert convert(['3945.0000', 'N', '12130.0000', 'W']) == (39.75, -121.5)
+	assert convert(['3945.0000', 'N', '12115.0000', 'W']) == (39.75, -121.25)
+	assert convert(['3945.0000', 'N', '12100.0000', 'W']) == (39.75, -121.0)
+	assert convert(['3945.0000', 'N', '12045.0000', 'W']) == (39.75, -120.75)
+	assert convert(['3945.0000', 'N', '12030.0000', 'W']) == (39.75, -120.5)
+	assert convert(['3945.0000', 'N', '12015.0000', 'W']) == (39.75, -120.25)
+	assert convert(['3945.0000', 'N', '12000.0000', 'W']) == (39.75, -120.0)
+	assert convert(['3945.0000', 'N', '11945.0000', 'W']) == (39.75, -119.75)
+	assert convert(['3945.0000', 'N', '11930.0000', 'W']) == (39.75, -119.5)
+	assert convert(['3945.0000', 'N', '11915.0000', 'W']) == (39.75, -119.25)
+	assert convert(['3945.0000', 'N', '11900.0000', 'W']) == (39.75, -119.0)
+	assert convert(['4000.0000', 'N', '12130.0000', 'W']) == (40.0, -121.5)
+	assert convert(['4000.0000', 'N', '12115.0000', 'W']) == (40.0, -121.25)
+	assert convert(['4000.0000', 'N', '12100.0000', 'W']) == (40.0, -121.0)
+	assert convert(['4000.0000', 'N', '12045.0000', 'W']) == (40.0, -120.75)
+	assert convert(['4000.0000', 'N', '12030.0000', 'W']) == (40.0, -120.5)
+	assert convert(['4000.0000', 'N', '12015.0000', 'W']) == (40.0, -120.25)
+	assert convert(['4000.0000', 'N', '12000.0000', 'W']) == (40.0, -120.0)
+	assert convert(['4000.0000', 'N', '11945.0000', 'W']) == (40.0, -119.75)
+	assert convert(['4000.0000', 'N', '11930.0000', 'W']) == (40.0, -119.5)
+	assert convert(['4000.0000', 'N', '11915.0000', 'W']) == (40.0, -119.25)
+	assert convert(['4000.0000', 'N', '11900.0000', 'W']) == (40.0, -119.0)
+

--- a/utility/misc_functions.py
+++ b/utility/misc_functions.py
@@ -2,7 +2,7 @@ import re, time
 
 def getFileNameBase(root):
 	"""Adds a timestamp to the given string (a root filename)."""
-	return root+"_"+timestamp()
+	return root ################################################################# +"_"+timestamp()
 
 def timestamp(theTime=time.localtime()):
 	return time.strftime("%Y_%m_%d_%H%M%S",theTime)


### PR DESCRIPTION
Major refactoring of the mapping logic: 
- Created a new class called class DecimalDegrees, being our base (common) representation of a point on the globe. (Everything gets converted into or out of DecimalDegrees.)
- Added an enum for the (base) CRS codes (without the UTM zone added).
- Our DecimalDegrees object now saves copies of the original attributes as constructed, allowing the working copies to morph.
- Extracted the validation of NMEA coordinates to validateNMEACoords()
- fromNMEA() is now a static method, so it can be called before (as) the DecimalDegrees is instantiated.
- Extracted determining the source and target CRS codes to fromEPSG() and toEPSG(), respectively.
- Extracted the math that converts from D.d to DM.m and DMS.s to toDEGMIN() and toDMS(), respectively.

Also: Commented out timestamping the log file, for now. (So that it's easier to just keep refreshing the one file that's open in the editor.)