### PR TITLE
Printing stuff (e.g. Fillable PDFs) and related

### DIFF
--- a/app/command_line.py
+++ b/app/command_line.py
@@ -18,7 +18,7 @@ def parse_args(args) -> argparse.Namespace:
     Note: --version and --help are handled immediately as they are parsed.
       In both cases, parse_args will raise a SystemExit exception
     """
-    parser = basic_cli_parser(version_text= __version__, verbose=True, very_verbose=True, nocolor=True, devel=True, trace=True, configfile_default="./local/radiolog.cfg", logfile_default="RadioLog_log.txt")
+    parser = basic_cli_parser(version_text= __version__, verbose=True, very_verbose=True, nocolor=True, devel=True, trace=True, configfile_default="./local/radiolog.ini", logfile_default="RadioLog_log.txt")
     parser.add_argument("-m", "--min", dest="minmode", help="minimum display size mode enabled", action="store_true", default=False)
     parser.add_argument("--nosend", dest="nosend", help="will not send any GET requests for this session", action="store_true", default=False)
     parser.add_argument("--nologfile", dest="nologfile", help="suppresses using a log file, relying on just the console", action="store_true", default=False)

--- a/app/command_line.py
+++ b/app/command_line.py
@@ -6,7 +6,7 @@ __version__ = "2.0.2"
 
 # KEEP IN MIND: logging has not been set up yet. Don't try to make logging calls in here.
 
-def parse_args(args):
+def parse_args(args) -> argparse.Namespace:
     """Parse any command line parameters.
 
     Args:

--- a/app/config.py
+++ b/app/config.py
@@ -1,3 +1,5 @@
+import os
+from app.db.file_management import determine_rotate_method
 from dataclasses import dataclass
 from app.logic.mapping import Datum, CoordFormat
 from pathlib import Path
@@ -12,102 +14,114 @@ DEFAULT_LOGO = 'radiolog_logo.jpg'
 DEFAULT_CLUE_REPORT = 'clueReportFillable.pdf'
 DEFAULT_TIMEOUT = 30
 DEFAULT_WORKINGDIR = 'testdata'
-
+DEFAULT_SARSOFT_SERVER = "localhost"
 
 def _as_path(input: str) -> Path:
-	return Path(input)
+    return Path(input)
 
 def _as_datum(input: str) -> Datum:
-	return Datum.__members__[input]
+    return Datum.__members__[input]
 
 def _as_coordFormat(input: str) -> CoordFormat:
-	return CoordFormat.__members__[input]
+    return CoordFormat.__members__[input]
 
 CONVERTERS = {
-	'path': _as_path,
-	'datum': _as_datum,
-	'coordformat': _as_coordFormat
+    'path': _as_path,
+    'datum': _as_datum,
+    'coordformat': _as_coordFormat
 }
 
+
 def __agency_section(parser, config):
-	config.agencyName = DEFAULT_NAME
-	config.logo= Path(DEFAULT_LOGO)
-	if parser.has_section('agency'):
-		config.agencyName = parser.get('agency', 'name', fallback=config.agencyName)
-		config.logo = parser['agency'].getpath('logo', config.logo)
+    config.agencyName = DEFAULT_NAME
+    config.logo = Path(DEFAULT_LOGO)
+    if parser.has_section('agency'):
+        config.agencyName = parser.get('agency', 'name', fallback=config.agencyName)
+        config.logo = parser['agency'].getpath('logo', config.logo)
 
 def __storage_section(parser, config):
-	config.firstWorkingDir = Path(DEFAULT_WORKINGDIR)
-	config.secondWorkingDir = None
-	if parser.has_section('storage'):
-		config.firstWorkingDir = parser['storage'].getpath('firstworkingdir', config.firstWorkingDir)
-		config.secondWorkingDir = parser['storage'].getpath('secondworkingdir', config.secondWorkingDir)
+    config.firstWorkingDir = Path(DEFAULT_WORKINGDIR)
+    config.secondWorkingDir = None
+    (config.rotateScript, config.rotateDelimiter) = determine_rotate_method()
+
+    if parser.has_section('storage'):
+        config.firstWorkingDir = parser['storage'].getpath('firstworkingdir', config.firstWorkingDir)
+        config.secondWorkingDir = parser['storage'].getpath('secondworkingdir', config.secondWorkingDir)
+        config.rotateScript = parser.get('storage', "rotateScript", fallback=config.rotateScript)
+        config.rotateDelimiter = parser.get('storage', "rotateDelimiter", fallback=config.rotateDelimiter)
 
 def __display_section(parser, config):
-	config.timeoutMinutes = DEFAULT_TIMEOUT  # initial timeout interval (valid: 10..120 step 10)
-	if parser.has_section('display'):
-		config.timeoutMinutes = parser['display'].getint('timeoutminutes', config.timeoutMinutes)
+    config.timeoutMinutes = DEFAULT_TIMEOUT  # initial timeout interval (valid: 10..120 step 10)
+    if parser.has_section('display'):
+        config.timeoutMinutes = parser['display'].getint('timeoutminutes', config.timeoutMinutes)
 
 def __tabgroups_section(parser, config):
-	config.tabGroups = []
-	if parser.has_section('tabgroups'):
-		config.tabGroups = []
-		for (tabName,tabRE) in parser['tabgroups'].items():
-			config.tabGroups.append(tabRE)
+    config.tabGroups = []
+    if parser.has_section('tabgroups'):
+        config.tabGroups = []
+        for (tabName,tabRE) in parser['tabgroups'].items():
+            config.tabGroups.append(tabRE)
 
 def __reports_section(parser, config):
-	config.clueReport = Path(DEFAULT_CLUE_REPORT)
-	if parser.has_section('reports'):
-		config.clueReport = parser['reports'].getpath('cluereport', config.clueReport)
+    config.clueReport = Path(DEFAULT_CLUE_REPORT)
+    if parser.has_section('reports'):
+        config.clueReport = parser['reports'].getpath('cluereport', config.clueReport)
 
 def __mapping_section(parser, config, issues):
-	config.datum = Datum.WGS84
-	config.coordFormat = CoordFormat.UTM7
-	if parser.has_section('mapping'):
-		try:
-			config.datum = parser['mapping'].getdatum('datum', config.datum)
-		except KeyError as e:
-			issues.append(RadioLogConfigSettingWarning("[mapping]datum", e.args[0], Datum.possibleValues()))
+    config.datum = Datum.WGS84
+    config.coordFormat = CoordFormat.UTM7
+    if parser.has_section('mapping'):
+        try:
+            config.datum = parser['mapping'].getdatum('datum', config.datum)
+        except KeyError as e:
+            issues.append(RadioLogConfigSettingWarning("[mapping]datum", e.args[0], Datum.possibleValues()))
 
-		try:
-			config.coordFormat = parser['mapping'].getcoordformat('coordformat', config.coordFormat)
-		except KeyError as e:
-			issues.append(RadioLogConfigSettingWarning("[mapping]coordformat", e.args[0], CoordFormat.possibleValues()))
+        try:
+            config.coordFormat = parser['mapping'].getcoordformat('coordformat', config.coordFormat)
+        except KeyError as e:
+            issues.append(RadioLogConfigSettingWarning("[mapping]coordformat", e.args[0], CoordFormat.possibleValues()))
+
+def __interop_section(parser, config, issues):
+    config.sarsoftServerName = DEFAULT_SARSOFT_SERVER
+    if parser.has_section('interop'):
+        config.sarsoftServerName = parser.get('RadioLog', "server")
 
 def load_config(filename: str = "", ini: str = "", config: argparse.Namespace = None) -> argparse.Namespace:
-	"""
-	Parse the contents of the config (INI) file.
+    """
+    Parse the contents of the config (INI) file.
 
-	Args:
-	  filename -- the name of the file to be parsed, or...
-	  ini -- the actual text to be parsed
-	  config (optional) -- An existing argparse.Namespace to be appended to
+    Args:
+      filename -- the name of the file to be parsed, or...
+      ini -- the actual text to be parsed
+      config (optional) -- An existing argparse.Namespace to be appended to
 
-	Returns:
-	  An object of type argparse.Namespace. Access the settings as object attributes (e.g. config.datum).
-	"""
-	LOG.trace("Loading config")
-	parser = configparser.ConfigParser(converters=CONVERTERS)
-	if filename:
-		parser.read_file(filename)
-	else:
-		parser.read_string(ini)
+    Returns:
+      An object of type argparse.Namespace. Access the settings as object attributes (e.g. config.datum).
+    """
+    LOG.trace("Loading config")
+    parser = configparser.ConfigParser(converters=CONVERTERS)
+    if filename:
+        parser.read_file(open(filename,encoding="UTF-8"))
+    else:
+        parser.read_string(ini)
 
-	if not config:
-		config = argparse.Namespace()
+    if not config:
+        config = argparse.Namespace()
 
-	issues = []
-	__agency_section(parser, config)
-	__display_section(parser, config)
-	__tabgroups_section(parser, config)
-	__reports_section(parser, config)
-	__mapping_section(parser, config, issues)
-	__storage_section(parser, config)
+    issues = []
+    __agency_section(parser, config)
+    __display_section(parser, config)
+    __tabgroups_section(parser, config)
+    __reports_section(parser, config)
+    __mapping_section(parser, config, issues)
+    __storage_section(parser, config)
+    __interop_section(parser, config, issues)
 
-	for issue in issues:
-		LOG.exception(issue)
+    for issue in issues:
+        LOG.exception(issue)
 
-	return config
+    LOG.debug(f"config = {config}")
+    return config
 
 __all__ = ("load_config")
 

--- a/app/db/file_management.py
+++ b/app/db/file_management.py
@@ -1,48 +1,59 @@
 import os,shutil,logging
+from pathlib import Path
 from typing import Optional, Tuple
 from app.logic.app_state import CONFIG
 
 LOG = logging.getLogger("main")
 
 def getFileNameBase(root):
-	"""Adds a timestamp to the given string (a root filename)."""
-	return root  # +"_"+timestamp()
+    """Adds a timestamp to the given string (a root filename)."""
+    return root  # +"_"+timestamp()
 
 def ensureLocalDirectoryExists():
-	"""
-	create the local dir if it doesn't already exist, and populate it
-	with files from local_default.
-	"""
-	issue = ""
-	if not os.path.isdir("local"):
-		issue = "'local' directory not found; copying 'local_default' to 'local'; you may want to edit local/radiolog.cfg"
-		LOG.warn(issue)
-		shutil.copytree("local_default", "local")
-	elif not os.path.isfile("local/radiolog.cfg"):
-		issue = "'local' directory was found but did not contain radiolog.cfg; copying from local_default"
-		LOG.warn(issue)
-		shutil.copyfile("local_default/radiolog.cfg", "local/radiolog.cfg")
-	return issue
+    """
+    create the local dir if it doesn't already exist, and populate it
+    with files from local_default.
+    """
+    issue = ""
+    if not os.path.isdir("local"):
+        issue = "'local' directory not found; copying 'local_default' to 'local'; you may want to edit local/radiolog.cfg"
+        LOG.warn(issue)
+        shutil.copytree("local_default", "local")
+    elif not os.path.isfile("local/radiolog.cfg"):
+        issue = "'local' directory was found but did not contain radiolog.cfg; copying from local_default"
+        LOG.warn(issue)
+        shutil.copyfile("local_default/radiolog.cfg", "local/radiolog.cfg")
+    return issue
 
 def determine_rotate_method() -> Tuple[Optional[str], Optional[str]]:
-	rotateScript = None
-	rotateDelimiter = None
-	if os.name == "nt":
-		LOG.info("Operating system is Windows.")
-		if shutil.which("powershell.exe"):
-			LOG.info("PowerShell.exe is in the path.")
-			rotateScript = "powershell.exe -ExecutionPolicy Bypass .\\rotateCsvBackups.ps1 -filenames "
-			rotateDelimiter = ","
-		else:
-			LOG.warn("PowerShell.exe is not in the path; poweshell-based backup rotation script cannot be used.")
-	else:
-		LOG.warn("Operating system is not Windows.  Powershell-based backup rotation script cannot be used.")
-	return (rotateScript, rotateDelimiter)
+    rotateScript = None
+    rotateDelimiter = None
+    if os.name == "nt":
+        LOG.info("Operating system is Windows.")
+        if shutil.which("powershell.exe"):
+            LOG.info("PowerShell.exe is in the path.")
+            rotateScript = "powershell.exe -ExecutionPolicy Bypass .\\rotateCsvBackups.ps1 -filenames "
+            rotateDelimiter = ","
+        else:
+            LOG.warn("PowerShell.exe is not in the path; poweshell-based backup rotation script cannot be used.")
+    else:
+        LOG.warn("Operating system is not Windows.  Powershell-based backup rotation script cannot be used.")
+    return (rotateScript, rotateDelimiter)
+
+def viable_2wd():
+    """
+    Returns the Path() of the second working dir, if it exists and we're using it.
+    Otherwise, None.
+    """
+    if CONFIG.use2WD and CONFIG.secondWorkingDir and os.path.isdir(CONFIG.secondWorkingDir):
+        return Path(CONFIG.secondWorkingDir)
+    return None
+
 
 def make_backup_copy(filename):
-    if CONFIG.use2WD and CONFIG.secondWorkingDir and os.path.isdir(CONFIG.secondWorkingDir):
-        LOG.debug(f"Copying {filename} to {CONFIG.secondWorkingDir}")
-        shutil.copy(filename, CONFIG.secondWorkingDir)
+    if (path2wd := viable_2wd()):
+        LOG.debug(f"Copying {filename} to {path2wd}")
+        shutil.copy(filename, path2wd)
 
 
-__all__ = ("getFileNameBase", "ensureLocalDirectoryExists", "determine_rotate_method", "make_backup_copy")
+__all__ = ("getFileNameBase", "ensureLocalDirectoryExists", "determine_rotate_method", "make_backup_copy", "viable_2wd")

--- a/app/db/file_management.py
+++ b/app/db/file_management.py
@@ -1,5 +1,6 @@
 import os,shutil,logging
 from typing import Optional, Tuple
+from app.logic.app_state import CONFIG
 
 LOG = logging.getLogger("main")
 
@@ -38,4 +39,10 @@ def determine_rotate_method() -> Tuple[Optional[str], Optional[str]]:
 		LOG.warn("Operating system is not Windows.  Powershell-based backup rotation script cannot be used.")
 	return (rotateScript, rotateDelimiter)
 
-__all__ = ("getFileNameBase", "ensureLocalDirectoryExists")
+def make_backup_copy(filename):
+    if CONFIG.use2WD and CONFIG.secondWorkingDir and os.path.isdir(CONFIG.secondWorkingDir):
+        LOG.debug(f"Copying {filename} to {CONFIG.secondWorkingDir}")
+        shutil.copy(filename, CONFIG.secondWorkingDir)
+
+
+__all__ = ("getFileNameBase", "ensureLocalDirectoryExists", "determine_rotate_method", "make_backup_copy")

--- a/app/logic/app_state.py
+++ b/app/logic/app_state.py
@@ -10,6 +10,8 @@ import argparse
 SWITCHES: argparse.Namespace = parse_args(sys.argv[1:])
 # print(f"SWITCHES = {SWITCHES}")
 
+CONFIG: argparse.Namespace = argparse.Namespace()
+
 TIMEOUT_DISPLAY_LIST = [["10 sec", 10]]
 for n in range(1, 13):
     TIMEOUT_DISPLAY_LIST.append([str(n * 10) + " min", n * 600])

--- a/app/logic/app_state.py
+++ b/app/logic/app_state.py
@@ -1,8 +1,20 @@
-# Various globals and constants used through the application
+"""
+Various globals and constants used through the application
+"""
+
+import sys
+from app.command_line import parse_args
+import argparse
+
+
+SWITCHES: argparse.Namespace = parse_args(sys.argv[1:])
+# print(f"SWITCHES = {SWITCHES}")
 
 TIMEOUT_DISPLAY_LIST = [["10 sec", 10]]
 for n in range(1, 13):
     TIMEOUT_DISPLAY_LIST.append([str(n * 10) + " min", n * 600])
+
+
 
 holdSec = 20
 continueSec = 20

--- a/app/printing/print_clue_log.py
+++ b/app/printing/print_clue_log.py
@@ -1,0 +1,117 @@
+import logging
+import functools
+import shutil
+import argparse
+import os
+from time import time
+
+from app.logic.app_state import SWITCHES
+from PyQt5.QtCore import QCoreApplication
+from gwpycore import inform_user_about_issue, print_pdf, view_pdf
+from reportlab.lib import colors, utils
+from reportlab.lib.pagesizes import letter, landscape
+from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, Paragraph, Image
+from reportlab.lib.styles import getSampleStyleSheet
+from reportlab.lib.units import inch
+
+LOG = logging.getLogger('main')
+
+
+def printClueLogHeaderFooter(canvas, doc, printParams: argparse.Namespace, opPeriod=""):
+    canvas.saveState()
+    styles = getSampleStyleSheet()
+    logoImage = None
+    if os.path.isfile(printParams.printLogoFileName):
+        imgReader = utils.ImageReader(printParams.printLogoFileName)
+        imgW, imgH = imgReader.getSize()
+        imgAspect = imgH / float(imgW)
+        logoImage = Image(printParams.printLogoFileName, width=0.54 * inch / float(imgAspect), height=0.54 * inch)
+        headerTable = [
+            [logoImage, printParams.agencyNameForPrint, "Incident: " + printParams.incidentName, "Clue Log - Page " + str(canvas.getPageNumber())],
+                ["", "", "Operational Period: " + str(opPeriod), "Printed: " + time.strftime("%a %b %d, %Y  %H:%M")]]
+        t = Table(headerTable, colWidths=[x * inch for x in [0.8, 4.2, 2.5, 2.5]], rowHeights=[x * inch for x in [0.3, 0.3]])
+        t.setStyle(TableStyle([('FONT', (1, 0), (1, 1), 'Helvetica-Bold'),
+                                ('FONTSIZE', (1, 0), (1, 1), 18),
+                                        ('SPAN', (0, 0), (0, 1)),
+                                        ('SPAN', (1, 0), (1, 1)),
+                                        ('LEADING', (1, 0), (1, 1), 20),
+                                        ('TOPADDING', (1, 0), (1, 0), 0),
+                                        ('BOTTOMPADDING', (1, 1), (1, 1), 4),
+                                ('VALIGN', (0, 0), (-1, -1), "MIDDLE"),
+                                ('ALIGN', (1, 0), (1, -1), "CENTER"),
+                                        ('ALIGN', (0, 0), (0, 1), "CENTER"),
+                                        ('BOX', (0, 0), (-1, -1), 2, colors.black),
+                                        ('BOX', (2, 0), (-1, -1), 2, colors.black),
+                                        ('INNERGRID', (2, 0), (3, 1), 0.5, colors.black)]))
+    else:
+        headerTable = [
+            [logoImage, printParams.agencyNameForPrint, "Incident: " + printParams.incidentName, "Clue Log - Page " + str(canvas.getPageNumber())],
+                ["", "", "Operational Period: " + str(opPeriod), "Printed: " + time.strftime("%a %b %d, %Y  %H:%M")]]
+        t = Table(headerTable, colWidths=[x * inch for x in [0.0, 5, 2.5, 2.5]], rowHeights=[x * inch for x in [0.3, 0.3]])
+        t.setStyle(TableStyle([('FONT', (1, 0), (1, 1), 'Helvetica-Bold'),
+                                ('FONTSIZE', (1, 0), (1, 1), 18),
+                                        ('SPAN', (0, 0), (0, 1)),
+                                        ('SPAN', (1, 0), (1, 1)),
+                                        ('LEADING', (1, 0), (1, 1), 20),
+                                ('VALIGN', (1, 0), (-1, -1), "MIDDLE"),
+                                ('ALIGN', (1, 0), (1, -1), "CENTER"),
+                                        ('BOX', (0, 0), (-1, -1), 2, colors.black),
+                                        ('BOX', (2, 0), (-1, -1), 2, colors.black),
+                                        ('INNERGRID', (2, 0), (3, 1), 0.5, colors.black)]))
+    w, h = t.wrapOn(canvas, doc.width, doc.height)
+# 		self.clueLogMsgBox.setInformativeText("Generating page "+str(canvas.getPageNumber()))
+    QCoreApplication.processEvents()
+    LOG.debug("Page number:" + str(canvas.getPageNumber()))
+    LOG.debug("Height:" + str(h))
+    LOG.debug("Pagesize:" + str(doc.pagesize))
+    t.drawOn(canvas, doc.leftMargin, doc.pagesize[1] - h - 0.5 * inch)  # enforce a 0.5 inch top margin regardless of paper size
+    LOG.trace("done drawing printClueLogHeaderFooter canvas")
+    canvas.restoreState()
+    LOG.trace("end of printClueLogHeaderFooter")
+
+
+def printClueLog(opPeriod, printParams: argparse.Namespace):
+    ##      header_labels=['#','DESCRIPTION','TEAM','TIME','DATE','O.P.','LOCATION','INSTRUCTIONS','RADIO LOC.']
+    opPeriod = int(opPeriod)
+    clueLogPdfFileName = printParams.firstWorkingDir + "\\" + printParams.pdfFileName.replace(".pdf", "_clueLog_OP" + str(opPeriod) + ".pdf")
+    LOG.trace("generating clue log pdf: " + clueLogPdfFileName)
+    try:
+        f = open(clueLogPdfFileName, "wb")
+    except:
+        inform_user_about_issue("PDF could not be generated:\n\n" + clueLogPdfFileName + "\n\nMaybe the file is currently being viewed by another program?  If so, please close that viewer and try again.  As a last resort, the auto-saved CSV file can be printed from Excel or as a plain text file.",
+                                timeout=10000)
+        return
+    else:
+        f.close()
+    # note the topMargin is based on what looks good; you would think that a 0.6 table plus a 0.5 hard
+    # margin (see t.drawOn above) would require a 1.1 margin here, but, not so.
+    doc = SimpleDocTemplate(clueLogPdfFileName, pagesize=landscape(letter), leftMargin=0.5*inch, rightMargin=0.5*inch, topMargin=1.03*inch, bottomMargin=0.5*inch) # or pagesize=letter
+    QCoreApplication.processEvents()
+    elements = []
+    styles = getSampleStyleSheet()
+    clueLogPrint = []
+    clueLogPrint.append(printParams.clue_log_header_labels[0:5] + printParams.clue_log_header_labels[6:8])  # omit operational period
+    for row in printParams.clueLog:
+        LOG.debug("clue: opPeriod=" + str(opPeriod) + "; row=" + str(row))
+        if (str(row[5]) == str(opPeriod) or row[1].startswith("Operational Period "+str(opPeriod)+" Begins:") or (opPeriod == 1 and row[1].startswith("Radio Log Begins:"))):
+            clueLogPrint.append([row[0], Paragraph(row[1], styles['Normal']), row[2], row[3],row[4],Paragraph(row[6],styles['Normal']),Paragraph(row[7],styles['Normal'])])
+    clueLogPrint[1][5] = printParams.datum
+    if len(clueLogPrint) > 2:
+        ##			t=Table(clueLogPrint,repeatRows=1,colWidths=[x*inch for x in [0.6,3.75,.9,0.5,1.25,3]])
+        t = Table(clueLogPrint, repeatRows=1, colWidths=[x*inch for x in [0.3, 3.75,0.9,0.5,0.8,1.25,2.5]])
+        t.setStyle(TableStyle([('F/generating clue llONT', (0, 0), (-1, -1),'Helvetica'),
+                                ('FONT', (0, 0), (-1, 1),'Helvetica-Bold'),
+                                ('INNERGRID', (0, 0), (-1, -1), 0.25, colors.black),
+                                ('BOX', (0, 0), (-1, -1), 2, colors.black),
+                                ('BOX', (0, 0), (6, 0), 2, colors.black)]))
+        elements.append(t)
+        doc.build(elements, onFirstPage=functools.partial(printClueLogHeaderFooter, printParams=printParams, opPeriod=opPeriod), onLaterPages=functools.partial(printClueLogHeaderFooter, printParams=printParams, opPeriod=opPeriod))
+# 			self.clueLogMsgBox.setInformativeText("Finalizing and Printing...")
+        if SWITCHES.devmode:
+            view_pdf(clueLogPdfFileName)
+        else:
+            print_pdf(clueLogPdfFileName)
+        if printParams.use2WD and printParams.secondWorkingDir and os.path.isdir(printParams.secondWorkingDir):
+            LOG.trace("copying clue log pdf to " + printParams.secondWorkingDir)
+            shutil.copy(clueLogPdfFileName, printParams.secondWorkingDir)
+

--- a/app/printing/print_clue_log.py
+++ b/app/printing/print_clue_log.py
@@ -1,6 +1,6 @@
+from app.db.file_management import make_backup_copy
 import logging
 import functools
-import shutil
 import argparse
 import os
 from time import time
@@ -111,7 +111,5 @@ def printClueLog(opPeriod, printParams: argparse.Namespace):
             view_pdf(clueLogPdfFileName)
         else:
             print_pdf(clueLogPdfFileName)
-        if printParams.use2WD and printParams.secondWorkingDir and os.path.isdir(printParams.secondWorkingDir):
-            LOG.trace("copying clue log pdf to " + printParams.secondWorkingDir)
-            shutil.copy(clueLogPdfFileName, printParams.secondWorkingDir)
+        make_backup_copy(clueLogPdfFileName)
 

--- a/app/printing/print_clue_log.py
+++ b/app/printing/print_clue_log.py
@@ -5,7 +5,7 @@ import argparse
 import os
 from time import time
 
-from app.logic.app_state import SWITCHES
+from app.logic.app_state import CONFIG, SWITCHES
 from PyQt5.QtCore import QCoreApplication
 from gwpycore import inform_user_about_issue, print_pdf, view_pdf
 from reportlab.lib import colors, utils
@@ -73,7 +73,7 @@ def printClueLogHeaderFooter(canvas, doc, printParams: argparse.Namespace, opPer
 def printClueLog(opPeriod, printParams: argparse.Namespace):
     ##      header_labels=['#','DESCRIPTION','TEAM','TIME','DATE','O.P.','LOCATION','INSTRUCTIONS','RADIO LOC.']
     opPeriod = int(opPeriod)
-    clueLogPdfFileName = printParams.firstWorkingDir + "\\" + printParams.pdfFileName.replace(".pdf", "_clueLog_OP" + str(opPeriod) + ".pdf")
+    clueLogPdfFileName = CONFIG.firstWorkingDir + "\\" + printParams.pdfFileName.replace(".pdf", "_clueLog_OP" + str(opPeriod) + ".pdf")
     LOG.trace("generating clue log pdf: " + clueLogPdfFileName)
     try:
         f = open(clueLogPdfFileName, "wb")

--- a/app/printing/print_clue_report.py
+++ b/app/printing/print_clue_report.py
@@ -1,19 +1,12 @@
+from app.db.file_management import make_backup_copy
 import logging
-import functools
-import shutil
 import argparse
-import os
 import time
 import re
 
 from PyQt5.QtCore import QCoreApplication
 from gwpycore.gw_gui.gw_gui_dialogs import ICON_WARN, inform_user_about_issue
 from gwpycore.gw_windows_specific.gw_windows_printing import fill_in_pdf, print_pdf, view_pdf
-from reportlab.lib import colors, utils
-from reportlab.lib.pagesizes import letter, landscape
-from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, Paragraph, Image
-from reportlab.lib.styles import getSampleStyleSheet
-from reportlab.lib.units import inch
 from app.logic.app_state import SWITCHES
 
 LOG = logging.getLogger('main')
@@ -68,6 +61,4 @@ def printClueReport(clueData, printParams: argparse.Namespace):
         view_pdf(cluePdfName)
     else:
         print_pdf(cluePdfName)
-    if printParams.use2WD and printParams.secondWorkingDir and os.path.isdir(printParams.secondWorkingDir):
-        LOG.trace("copying clue report pdf to " + printParams.secondWorkingDir)
-        shutil.copy(cluePdfName, printParams.secondWorkingDir)
+    make_backup_copy(cluePdfName)

--- a/app/printing/print_clue_report.py
+++ b/app/printing/print_clue_report.py
@@ -7,7 +7,7 @@ import re
 from PyQt5.QtCore import QCoreApplication
 from gwpycore.gw_gui.gw_gui_dialogs import ICON_WARN, inform_user_about_issue
 from gwpycore.gw_windows_specific.gw_windows_printing import fill_in_pdf, print_pdf, view_pdf
-from app.logic.app_state import SWITCHES
+from app.logic.app_state import CONFIG, SWITCHES
 
 LOG = logging.getLogger('main')
 
@@ -19,7 +19,7 @@ def printClueReport(clueData, printParams: argparse.Namespace):
 
 ##		header_labels=['#','DESCRIPTION','TEAM','TIME','DATE','O.P.','LOCATION','INSTRUCTIONS','RADIO LOC.']
     # do not use ui object here, since this could be called later, when the clueDialog is not open
-    cluePdfName = printParams.firstWorkingDir +"\\" +printParams.pdfFileName.replace(".pdf", "_clue" +str(clueData[0]).zfill(2) +".pdf")
+    cluePdfName = CONFIG.firstWorkingDir +"\\" +printParams.pdfFileName.replace(".pdf", "_clue" +str(clueData[0]).zfill(2) +".pdf")
     LOG.trace("generating clue report pdf: " + cluePdfName)
 
     instructions = clueData[7].lower()

--- a/app/printing/print_clue_report.py
+++ b/app/printing/print_clue_report.py
@@ -1,0 +1,73 @@
+import logging
+import functools
+import shutil
+import argparse
+import os
+import time
+import re
+
+from PyQt5.QtCore import QCoreApplication
+from gwpycore.gw_gui.gw_gui_dialogs import ICON_WARN, inform_user_about_issue
+from gwpycore.gw_windows_specific.gw_windows_printing import fill_in_pdf, print_pdf, view_pdf
+from reportlab.lib import colors, utils
+from reportlab.lib.pagesizes import letter, landscape
+from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, Paragraph, Image
+from reportlab.lib.styles import getSampleStyleSheet
+from reportlab.lib.units import inch
+from app.logic.app_state import SWITCHES
+
+LOG = logging.getLogger('main')
+
+def printClueReport(clueData, printParams: argparse.Namespace):
+    if not printParams.fillableClueReportPdfFileName:
+        inform_user_about_issue("Reminder: no Clue Report form will be printed, since the fillable clue report PDF does not exist.\n\nThe clue report text is stored as part of the radio message text.\n\nThis warning will automatically close in a few seconds.",
+                                icon=ICON_WARN, title="Clue Report PDF Unavailable",  timeout=8000)
+        return
+
+##		header_labels=['#','DESCRIPTION','TEAM','TIME','DATE','O.P.','LOCATION','INSTRUCTIONS','RADIO LOC.']
+    # do not use ui object here, since this could be called later, when the clueDialog is not open
+    cluePdfName = printParams.firstWorkingDir +"\\" +printParams.pdfFileName.replace(".pdf", "_clue" +str(clueData[0]).zfill(2) +".pdf")
+    LOG.trace("generating clue report pdf: " + cluePdfName)
+
+    instructions = clueData[7].lower()
+    # initialize all checkboxes to OFF
+    instructionsCollect = ("collect" in instructions)
+    instructionsMarkAndLeave = ("mark & leave" in instructions)
+    instructionsDisregard = ("disregard" in instructions)
+    # now see if there are any instructions other than the standard ones above; if so, print them in 'other'
+    instructions = re.sub(r'collect', '', instructions)
+    instructions = re.sub(r'mark & leave', '', instructions)
+    instructions = re.sub(r'disregard', '', instructions)
+    instructions = re.sub(r'^[; ]+', '', instructions) # only get rid of semicolons and spaces before the first word
+    instructions = re.sub(r' ; ', '', instructions) # also get rid of remaining ' ; ' i.e. when first word is not a keyword
+    instructions = re.sub(r'; *$', '', instructions) # also get rid of trailing ';' i.e. when last word is a keyword
+    instructionsOther = (instructions != "")
+    instructionsOtherText = instructions
+
+    if clueData[8] != "":
+        radioLocText = "(Radio GPS: "+re.sub(r"\n", "  x  ", clueData[8])+")"
+    else:
+        radioLocText = ""
+    fields = {'titleField': printParams.agencyNameForPrint,
+              'incidentNameField': printParams.incidentName,
+              'dateField': time.strftime("%x"),
+              'operationalPeriodField': clueData[5],
+              'clueNumberField': clueData[0],
+              'dateTimeField': clueData[4] + "   " + clueData[3],
+              'teamField': clueData[2],
+              'descriptionField': clueData[1],
+              'locationRadioGPSField': radioLocText,
+              'locationField': clueData[6],
+              'instructionsCollectField': instructionsCollect,
+              'instructionsDisregardField': instructionsDisregard,
+              'instructionsMarkAndLeaveField': instructionsMarkAndLeave,
+              'instructionsOtherField': instructionsOther,
+              'instructionsOtherTextField': instructionsOtherText}
+    fill_in_pdf(printParams.fillableClueReportPdfFileName, fields, cluePdfName)
+    if SWITCHES.devmode:
+        view_pdf(cluePdfName)
+    else:
+        print_pdf(cluePdfName)
+    if printParams.use2WD and printParams.secondWorkingDir and os.path.isdir(printParams.secondWorkingDir):
+        LOG.trace("copying clue report pdf to " + printParams.secondWorkingDir)
+        shutil.copy(cluePdfName, printParams.secondWorkingDir)

--- a/app/printing/print_log.py
+++ b/app/printing/print_log.py
@@ -5,7 +5,7 @@ import argparse
 import os
 import time
 
-from app.logic.app_state import SWITCHES
+from app.logic.app_state import CONFIG, SWITCHES
 from app.logic.teams import getExtTeamName
 from PyQt5.QtCore import QCoreApplication
 from gwpycore import inform_user_about_issue, print_pdf, view_pdf
@@ -89,7 +89,7 @@ def printLog(opPeriod, printParams: argparse.Namespace, teams=False):
     if 'teams' is an array of team names, just print those team log(s)
     """
     opPeriod = int(opPeriod)
-    pdfName = printParams.firstWorkingDir + "\\" + printParams.pdfFileName
+    pdfName = CONFIG.firstWorkingDir + "\\" + printParams.pdfFileName
     teamFilterList = [""]  # by default, print print all entries; if teams=True, add a filter for each team
     msgAdder = ""
     if teams:

--- a/app/printing/print_log.py
+++ b/app/printing/print_log.py
@@ -1,13 +1,14 @@
 import logging
 import functools
 import shutil
-import argparse, os
+import argparse
+import os
 import time
 
+from app.logic.app_state import SWITCHES
 from app.logic.teams import getExtTeamName
 from PyQt5.QtCore import QCoreApplication
-from gwpycore.gw_gui.gw_gui_dialogs import inform_user_about_issue
-from gwpycore.gw_windows_specific.gw_windows_printing import print_pdf
+from gwpycore import inform_user_about_issue, print_pdf, view_pdf
 from reportlab.lib import colors, utils
 from reportlab.lib.pagesizes import letter, landscape
 from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, Paragraph, Image, Spacer
@@ -15,6 +16,7 @@ from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.lib.units import inch
 
 LOG = logging.getLogger('main')
+
 
 def printLogHeaderFooter(canvas, doc, printParams: argparse.Namespace, opPeriod="", teams=False):
     formNameText = "Radio Log"
@@ -67,24 +69,25 @@ def printLogHeaderFooter(canvas, doc, printParams: argparse.Namespace, opPeriod=
                                         ('BOX', (2, 0), (-1, -1), 2, colors.black),
                                         ('INNERGRID', (2, 0), (3, 1), 0.5, colors.black)]))
     w, h = t.wrapOn(canvas, doc.width, doc.height)
-# 		printParams.logMsgBox.setInformativeText("Generating page "+str(canvas.getPageNumber()))
     QCoreApplication.processEvents()
     LOG.debug("Page number:" + str(canvas.getPageNumber()))
     LOG.debug("Height:" + str(h))
     LOG.debug("Pagesize:" + str(doc.pagesize))
     t.drawOn(canvas, doc.leftMargin, doc.pagesize[1] - h - 0.5 * inch)  # enforce a 0.5 inch top margin regardless of paper size
-##		canvas.grid([x*inch for x in [0,0.5,1,1.5,2,2.5,3,3.5,4,4.5,5,5.5,6,6.5,7,7.5,8,8.5,9,9.5,10,10.5,11]],[y*inch for y in [0,0.5,1,1.5,2,2.5,3,3.5,4,4.5,5,5.5,6,6.5,7,7.5,8,8.5]])
+    # canvas.grid([x*inch for x in [0,0.5,1,1.5,2,2.5,3,3.5,4,4.5,5,5.5,6,6.5,7,7.5,8,8.5,9,9.5,10,10.5,11]],[y*inch for y in [0,0.5,1,1.5,2,2.5,3,3.5,4,4.5,5,5.5,6,6.5,7,7.5,8,8.5]])
     LOG.trace("done drawing printLogHeaderFooter canvas")
     canvas.restoreState()
     LOG.trace("end of printLogHeaderFooter")
 
-# optonal argument 'teams': if True, generate one pdf of all individual team logs;
-#  so, this function should be called once to generate the overall log pdf, and
-#  again with teams=True to generate team logs pdf
-# if 'teams' is an array of team names, just print those team log(s)
 
 
 def printLog(opPeriod, printParams: argparse.Namespace, teams=False):
+    """
+    Optional argument 'teams': if True, generate one pdf of all individual team logs;
+    so, this function should be called once to generate the overall log pdf, and
+    again with teams=True to generate team logs pdf
+    if 'teams' is an array of team names, just print those team log(s)
+    """
     opPeriod = int(opPeriod)
     pdfName = printParams.firstWorkingDir + "\\" + printParams.pdfFileName
     teamFilterList = [""]  # by default, print print all entries; if teams=True, add a filter for each team
@@ -95,7 +98,7 @@ def printLog(opPeriod, printParams: argparse.Namespace, teams=False):
             for team in teams:
                 printParams.printLog(opPeriod, team)
         elif isinstance(teams, str):
-            pdfName = pdfName.replace('.pdf', '_' +teams.replace(' ', '_').replace('.', '_') +'.pdf')
+            pdfName = pdfName.replace('.pdf', '_' + teams.replace(' ', '_').replace('.', '_') + '.pdf')
             msgAdder = " for " + teams
             teamFilterList = [teams]
         else:
@@ -116,12 +119,9 @@ def printLog(opPeriod, printParams: argparse.Namespace, teams=False):
         return
     else:
         f.close()
-# 		printParams.logMsgBox=QMessageBox(QMessageBox.Information,"Printing","Generating PDF"+msgAdder+"; will send to default printer automatically; please wait...",
-# 							QMessageBox.Abort,self,STD_DIALOG_OPTS)
-# 		printParams.logMsgBox.setInformativeText("Initializing...")
     # note the topMargin is based on what looks good; you would think that a 0.6 table plus a 0.5 hard
     # margin (see t.drawOn above) would require a 1.1 margin here, but, not so.
-    doc = SimpleDocTemplate(pdfName, pagesize=landscape(letter), leftMargin=0.5 *inch, rightMargin=0.5 *inch, topMargin=1.03 *inch, bottomMargin=0.5 *inch) # or pagesize=letter
+    doc = SimpleDocTemplate(pdfName, pagesize=landscape(letter), leftMargin=0.5 * inch, rightMargin=0.5 * inch, topMargin=1.03 * inch, bottomMargin=0.5 * inch)  # or pagesize=letter
 # 		printParams.logMsgBox.show()
 # 		QTimer.singleShot(5000,printParams.logMsgBox.close)
     QCoreApplication.processEvents()
@@ -131,28 +131,26 @@ def printLog(opPeriod, printParams: argparse.Namespace, teams=False):
         radioLogPrint = []
         styles = getSampleStyleSheet()
         radioLogPrint.append(printParams.header_labels[0:6])
-##			if teams and opPeriod==1: # if request op period = 1, include 'Radio Log Begins' in all team tables
-##				radioLogPrint.append(printParams.radioLog[0])
         entryOpPeriod = 1  # update this number when 'Operational Period <x> Begins' lines are found
-##			hits=False # flag to indicate whether this team has any entries in the requested op period; if not, don't make a table for this team
+        # hits=False # flag to indicate whether this team has any entries in the requested op period; if not, don't make a table for this team
         for row in printParams.radioLog:
             opStartRow = False
-##				LOG.debug("message:"+row[3]+":"+str(row[3].split()))
+            # LOG.debug("message:"+row[3]+":"+str(row[3].split()))
             if row[3].startswith("Radio Log Begins:"):
                 opStartRow = True
             if row[3].startswith("Operational Period") and row[3].split()[3] == "Begins:":
                 opStartRow = True
                 entryOpPeriod = int(row[3].split()[2])
-##				LOG.debug("desired op period="+str(opPeriod)+"; this entry op period="+str(entryOpPeriod))
+            # LOG.debug("desired op period="+str(opPeriod)+"; this entry op period="+str(entryOpPeriod))
             if entryOpPeriod == opPeriod:
                 if team == "" or extTeamNameLower == getExtTeamName(row[2]).lower() or opStartRow:  # filter by team name if argument was specified
-                    radioLogPrint.append([row[0], row[1], row[2], Paragraph(row[3], styles['Normal']), Paragraph(row[4],styles['Normal']),Paragraph(row[5],styles['Normal'])])
-##						hits=True
+                    radioLogPrint.append([row[0], row[1], row[2], Paragraph(row[3], styles['Normal']), Paragraph(row[4], styles['Normal']), Paragraph(row[5], styles['Normal'])])
+        # hits=True
         if not teams:
             radioLogPrint[1][4] = printParams.datum
         LOG.debug("length:" + str(len(radioLogPrint)))
         if not teams or len(radioLogPrint) > 2:  # don't make a table for teams that have no entries during the requested op period
-            t = Table(radioLogPrint, repeatRows=1, colWidths=[x*inch for x in [0.5, 0.6, 1.25,5.5,1.25,0.9]])
+            t = Table(radioLogPrint, repeatRows=1, colWidths=[x * inch for x in [0.5, 0.6, 1.25, 5.5, 1.25, 0.9]])
             t.setStyle(TableStyle([('FONT', (0, 0), (-1, -1), 'Helvetica'),
                                     ('FONT', (0, 0), (-1, 1), 'Helvetica-Bold'),
                                     ('INNERGRID', (0, 0), (-1, -1), 0.25, colors.black),
@@ -162,8 +160,10 @@ def printLog(opPeriod, printParams: argparse.Namespace, teams=False):
             if teams and team != teamFilterList[-1]:  # don't add a spacer after the last team - it could cause another page!
                 elements.append(Spacer(0, 0.25 * inch))
     doc.build(elements, onFirstPage=functools.partial(printLogHeaderFooter, opPeriod=opPeriod, printParams=printParams, teams=teams), onLaterPages=functools.partial(printLogHeaderFooter, opPeriod=opPeriod, printParams=printParams, teams=teams))
-# 		printParams.logMsgBox.setInformativeText("Finalizing and Printing...")
-    print_pdf(pdfName)
+    if SWITCHES.devmode:
+        view_pdf(pdfName)
+    else:
+        print_pdf(pdfName)
     printParams.radioLogNeedsPrint = False
 
     if printParams.use2WD and printParams.secondWorkingDir and os.path.isdir(printParams.secondWorkingDir):

--- a/app/printing/print_log.py
+++ b/app/printing/print_log.py
@@ -1,6 +1,6 @@
+from app.db.file_management import make_backup_copy
 import logging
 import functools
-import shutil
 import argparse
 import os
 import time
@@ -12,7 +12,7 @@ from gwpycore import inform_user_about_issue, print_pdf, view_pdf
 from reportlab.lib import colors, utils
 from reportlab.lib.pagesizes import letter, landscape
 from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, Paragraph, Image, Spacer
-from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+from reportlab.lib.styles import getSampleStyleSheet
 from reportlab.lib.units import inch
 
 LOG = logging.getLogger('main')
@@ -165,9 +165,6 @@ def printLog(opPeriod, printParams: argparse.Namespace, teams=False):
     else:
         print_pdf(pdfName)
     printParams.radioLogNeedsPrint = False
-
-    if printParams.use2WD and printParams.secondWorkingDir and os.path.isdir(printParams.secondWorkingDir):
-        LOG.debug("copying radio log pdf" + msgAdder + " to " + printParams.secondWorkingDir)
-        shutil.copy(pdfName, printParams.secondWorkingDir)
+    make_backup_copy(pdfName)
 
 

--- a/app/printing/print_log.py
+++ b/app/printing/print_log.py
@@ -1,0 +1,173 @@
+import logging
+import functools
+import shutil
+import argparse, os
+import time
+
+from app.logic.teams import getExtTeamName
+from PyQt5.QtCore import QCoreApplication
+from gwpycore.gw_gui.gw_gui_dialogs import inform_user_about_issue
+from gwpycore.gw_windows_specific.gw_windows_printing import print_pdf
+from reportlab.lib import colors, utils
+from reportlab.lib.pagesizes import letter, landscape
+from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, Paragraph, Image, Spacer
+from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+from reportlab.lib.units import inch
+
+LOG = logging.getLogger('main')
+
+def printLogHeaderFooter(canvas, doc, printParams: argparse.Namespace, opPeriod="", teams=False):
+    formNameText = "Radio Log"
+    if teams:
+        if isinstance(teams, str):
+            formNameText = "Team: " + teams
+        else:
+            formNameText = "Team Radio Logs"
+    canvas.saveState()
+    styles = getSampleStyleSheet()
+    logoImage = None
+    if os.path.isfile(printParams.printLogoFileName):
+        LOG.debug("valid logo file " + printParams.printLogoFileName)
+        imgReader = utils.ImageReader(printParams.printLogoFileName)
+        imgW, imgH = imgReader.getSize()
+        imgAspect = imgH / float(imgW)
+        logoImage = Image(printParams.printLogoFileName, width=0.54 * inch / float(imgAspect), height=0.54 * inch)
+        headerTable = [
+            [logoImage, printParams.agencyNameForPrint, "Incident: " + printParams.incidentName, formNameText + " - Page " + str(canvas.getPageNumber())],
+                ["", "", "Operational Period: " + str(opPeriod), "Printed: " + time.strftime("%a %b %d, %Y  %H:%M")]]
+        t = Table(headerTable, colWidths=[x * inch for x in [0.8, 4.2, 2.5, 2.5]], rowHeights=[x * inch for x in [0.3, 0.3]])
+        t.setStyle(TableStyle([('FONT', (1, 0), (1, 1), 'Helvetica-Bold'),
+                                        ('FONT', (2, 0), (3, 0), 'Helvetica-Bold'),
+                                ('FONTSIZE', (1, 0), (1, 1), 18),
+                                ('SPAN', (0, 0), (0, 1)),
+                                ('SPAN', (1, 0), (1, 1)),
+                                        ('LEADING', (1, 0), (1, 1), 20),
+                                        ('TOPADDING', (1, 0), (1, 0), 0),
+                                        ('BOTTOMPADDING', (1, 1), (1, 1), 4),
+                                ('VALIGN', (0, 0), (-1, -1), "MIDDLE"),
+                                ('ALIGN', (1, 0), (1, -1), "CENTER"),
+                                        ('ALIGN', (0, 0), (0, 1), "CENTER"),
+                                        ('BOX', (0, 0), (-1, -1), 2, colors.black),
+                                        ('BOX', (2, 0), (-1, -1), 2, colors.black),
+                                        ('INNERGRID', (2, 0), (3, 1), 0.5, colors.black)]))
+    else:
+        headerTable = [
+            [logoImage, printParams.agencyNameForPrint, "Incident: " + printParams.incidentName, formNameText + " - Page " + str(canvas.getPageNumber())],
+                ["", "", "Operational Period: ", "Printed: " + time.strftime("%a %b %d, %Y  %H:%M")]]
+        t = Table(headerTable, colWidths=[x * inch for x in [0.0, 5, 2.5, 2.5]], rowHeights=[x * inch for x in [0.3, 0.3]])
+        t.setStyle(TableStyle([('FONT', (1, 0), (1, 1), 'Helvetica-Bold'),
+                                ('FONT', (2, 0), (3, 0), 'Helvetica-Bold'),
+                                ('FONTSIZE', (1, 0), (1, 1), 18),
+                                ('SPAN', (0, 0), (0, 1)),
+                                ('SPAN', (1, 0), (1, 1)),
+                                        ('LEADING', (1, 0), (1, 1), 20),
+                                ('VALIGN', (1, 0), (-1, -1), "MIDDLE"),
+                                ('ALIGN', (1, 0), (1, -1), "CENTER"),
+                                        ('BOX', (0, 0), (-1, -1), 2, colors.black),
+                                        ('BOX', (2, 0), (-1, -1), 2, colors.black),
+                                        ('INNERGRID', (2, 0), (3, 1), 0.5, colors.black)]))
+    w, h = t.wrapOn(canvas, doc.width, doc.height)
+# 		printParams.logMsgBox.setInformativeText("Generating page "+str(canvas.getPageNumber()))
+    QCoreApplication.processEvents()
+    LOG.debug("Page number:" + str(canvas.getPageNumber()))
+    LOG.debug("Height:" + str(h))
+    LOG.debug("Pagesize:" + str(doc.pagesize))
+    t.drawOn(canvas, doc.leftMargin, doc.pagesize[1] - h - 0.5 * inch)  # enforce a 0.5 inch top margin regardless of paper size
+##		canvas.grid([x*inch for x in [0,0.5,1,1.5,2,2.5,3,3.5,4,4.5,5,5.5,6,6.5,7,7.5,8,8.5,9,9.5,10,10.5,11]],[y*inch for y in [0,0.5,1,1.5,2,2.5,3,3.5,4,4.5,5,5.5,6,6.5,7,7.5,8,8.5]])
+    LOG.trace("done drawing printLogHeaderFooter canvas")
+    canvas.restoreState()
+    LOG.trace("end of printLogHeaderFooter")
+
+# optonal argument 'teams': if True, generate one pdf of all individual team logs;
+#  so, this function should be called once to generate the overall log pdf, and
+#  again with teams=True to generate team logs pdf
+# if 'teams' is an array of team names, just print those team log(s)
+
+
+def printLog(opPeriod, printParams: argparse.Namespace, teams=False):
+    opPeriod = int(opPeriod)
+    pdfName = printParams.firstWorkingDir + "\\" + printParams.pdfFileName
+    teamFilterList = [""]  # by default, print print all entries; if teams=True, add a filter for each team
+    msgAdder = ""
+    if teams:
+        if isinstance(teams, list):
+            # recursively call this function for each team in list of teams
+            for team in teams:
+                printParams.printLog(opPeriod, team)
+        elif isinstance(teams, str):
+            pdfName = pdfName.replace('.pdf', '_' +teams.replace(' ', '_').replace('.', '_') +'.pdf')
+            msgAdder = " for " + teams
+            teamFilterList = [teams]
+        else:
+            pdfName = pdfName.replace('.pdf', '_teams.pdf')
+            msgAdder = " for individual teams"
+            teamFilterList = []
+            for team in printParams.allTeamsList:
+                if team != "dummy":
+                    teamFilterList.append(team)
+    LOG.debug("teamFilterList=" + str(teamFilterList))
+    pdfName = pdfName.replace('.pdf', '_OP' + str(opPeriod) + '.pdf')
+    LOG.debug("generating radio log pdf: " + pdfName)
+    try:
+        f = open(pdfName, "wb")
+    except:
+        inform_user_about_issue("PDF could not be generated:\n\n" + pdfName +
+                                "\n\nMaybe the file is currently being viewed by another program?  If so, please close that viewer and try again.  As a last resort, the auto-saved CSV file can be printed from Excel or as a plain text file.", parent=self)
+        return
+    else:
+        f.close()
+# 		printParams.logMsgBox=QMessageBox(QMessageBox.Information,"Printing","Generating PDF"+msgAdder+"; will send to default printer automatically; please wait...",
+# 							QMessageBox.Abort,self,STD_DIALOG_OPTS)
+# 		printParams.logMsgBox.setInformativeText("Initializing...")
+    # note the topMargin is based on what looks good; you would think that a 0.6 table plus a 0.5 hard
+    # margin (see t.drawOn above) would require a 1.1 margin here, but, not so.
+    doc = SimpleDocTemplate(pdfName, pagesize=landscape(letter), leftMargin=0.5 *inch, rightMargin=0.5 *inch, topMargin=1.03 *inch, bottomMargin=0.5 *inch) # or pagesize=letter
+# 		printParams.logMsgBox.show()
+# 		QTimer.singleShot(5000,printParams.logMsgBox.close)
+    QCoreApplication.processEvents()
+    elements = []
+    for team in teamFilterList:
+        extTeamNameLower = getExtTeamName(team).lower()
+        radioLogPrint = []
+        styles = getSampleStyleSheet()
+        radioLogPrint.append(printParams.header_labels[0:6])
+##			if teams and opPeriod==1: # if request op period = 1, include 'Radio Log Begins' in all team tables
+##				radioLogPrint.append(printParams.radioLog[0])
+        entryOpPeriod = 1  # update this number when 'Operational Period <x> Begins' lines are found
+##			hits=False # flag to indicate whether this team has any entries in the requested op period; if not, don't make a table for this team
+        for row in printParams.radioLog:
+            opStartRow = False
+##				LOG.debug("message:"+row[3]+":"+str(row[3].split()))
+            if row[3].startswith("Radio Log Begins:"):
+                opStartRow = True
+            if row[3].startswith("Operational Period") and row[3].split()[3] == "Begins:":
+                opStartRow = True
+                entryOpPeriod = int(row[3].split()[2])
+##				LOG.debug("desired op period="+str(opPeriod)+"; this entry op period="+str(entryOpPeriod))
+            if entryOpPeriod == opPeriod:
+                if team == "" or extTeamNameLower == getExtTeamName(row[2]).lower() or opStartRow:  # filter by team name if argument was specified
+                    radioLogPrint.append([row[0], row[1], row[2], Paragraph(row[3], styles['Normal']), Paragraph(row[4],styles['Normal']),Paragraph(row[5],styles['Normal'])])
+##						hits=True
+        if not teams:
+            radioLogPrint[1][4] = printParams.datum
+        LOG.debug("length:" + str(len(radioLogPrint)))
+        if not teams or len(radioLogPrint) > 2:  # don't make a table for teams that have no entries during the requested op period
+            t = Table(radioLogPrint, repeatRows=1, colWidths=[x*inch for x in [0.5, 0.6, 1.25,5.5,1.25,0.9]])
+            t.setStyle(TableStyle([('FONT', (0, 0), (-1, -1), 'Helvetica'),
+                                    ('FONT', (0, 0), (-1, 1), 'Helvetica-Bold'),
+                                    ('INNERGRID', (0, 0), (-1, -1), 0.25, colors.black),
+                                    ('BOX', (0, 0), (-1, -1), 2, colors.black),
+                                    ('BOX', (0, 0), (5, 0), 2, colors.black)]))
+            elements.append(t)
+            if teams and team != teamFilterList[-1]:  # don't add a spacer after the last team - it could cause another page!
+                elements.append(Spacer(0, 0.25 * inch))
+    doc.build(elements, onFirstPage=functools.partial(printLogHeaderFooter, opPeriod=opPeriod, printParams=printParams, teams=teams), onLaterPages=functools.partial(printLogHeaderFooter, opPeriod=opPeriod, printParams=printParams, teams=teams))
+# 		printParams.logMsgBox.setInformativeText("Finalizing and Printing...")
+    print_pdf(pdfName)
+    printParams.radioLogNeedsPrint = False
+
+    if printParams.use2WD and printParams.secondWorkingDir and os.path.isdir(printParams.secondWorkingDir):
+        LOG.debug("copying radio log pdf" + msgAdder + " to " + printParams.secondWorkingDir)
+        shutil.copy(pdfName, printParams.secondWorkingDir)
+
+

--- a/app/ui/clue_dialogs.py
+++ b/app/ui/clue_dialogs.py
@@ -1,3 +1,4 @@
+from app.printing.print_clue_report import printClueReport
 import re
 from gwpycore.gw_gui.gw_gui_dialogs import ICON_WARN, ask_user_to_confirm, inform_user_about_issue
 from app.logic.entries import rreplace
@@ -223,7 +224,7 @@ class nonRadioClueDialog(QDialog, NonRadioClueDialogSpec):
         self.parent.newEntry(self.values)
 
         if self.clueReportPrintCheckBox.isChecked():
-            self.parent.printClueReport(clueData)
+            printClueReport(clueData, self.parent.getPrintParams())
         LOG.debug("accepted - calling close")
 ##		# don't try self.close() here - it can cause the dialog to never close!  Instead use super().accept()
         self.parent.clueLogDialog.tableView.model().layoutChanged.emit()

--- a/app/ui/options_dialog.py
+++ b/app/ui/options_dialog.py
@@ -1,4 +1,4 @@
-from app.logic.app_state import TIMEOUT_DISPLAY_LIST
+from app.logic.app_state import CONFIG, TIMEOUT_DISPLAY_LIST
 from PyQt5 import uic
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QDialog
@@ -38,6 +38,7 @@ class OptionsDialog(QDialog, OptionsDialogSpec):
 
     def secondWorkingDirCB(self):
         self.parent.use2WD = self.secondWorkingDirCheckBox.isChecked()
+        CONFIG.use2WD = self.secondWorkingDirCheckBox.isChecked()
 
     def accept(self):
         # only save the rc file when the options dialog is accepted interactively;

--- a/app/ui/print_dialogs.py
+++ b/app/ui/print_dialogs.py
@@ -1,3 +1,4 @@
+from app.printing.print_log import printLog
 from gwpycore.gw_gui.gw_gui_dialogs import inform_user_about_issue
 from PyQt5 import uic
 from PyQt5.QtCore import Qt
@@ -40,10 +41,10 @@ class PrintDialog(QDialog, PrintDialogSpec):
         opPeriod = self.opPeriodComboBox.currentText()
         if self.radioLogField.isChecked():
             LOG.debug("PRINT radio log")
-            self.parent.printLog(opPeriod)
+            printLog(opPeriod, self.parent.getPrintParams())
         if self.teamRadioLogsField.isChecked():
             LOG.debug("PRINT team radio logs")
-            self.parent.printTeamLogs(opPeriod)
+            printLog(opPeriod, self.parent.getPrintParams(), teams=True)
         if self.clueLogField.isChecked():
             LOG.debug("PRINT clue log")
 # 			LOG.debug("  printDialog.accept.clueLog.trace1")

--- a/app/ui/print_dialogs.py
+++ b/app/ui/print_dialogs.py
@@ -1,3 +1,4 @@
+from app.printing.print_clue_log import printClueLog
 from app.printing.print_log import printLog
 from gwpycore.gw_gui.gw_gui_dialogs import inform_user_about_issue
 from PyQt5 import uic
@@ -76,7 +77,8 @@ class printClueLogDialog(QDialog, PrintClueLogDialogSpec):
             inform_user_about_issue("There are no clues to print.", title="No Clues to Print", parent=self)
             self.reject()
         else:
-            self.parent.printClueLog(opPeriod)
+            printClueLog(opPeriod, self.parent.getPrintParams())
+            self.parent.clueLogNeedsPrint = False
             LOG.trace("Called parent printClueLogDialog.accept")
             super(printClueLogDialog, self).accept()
             LOG.trace("Called super printClueLogDialog.accept")


### PR DESCRIPTION
== PRINTING STUFF
* Removed the external dependency on pdftk, in favor of PyPDF4 (using Craig's branch until they accept his pull-request).
* Extracted the print log function, the print clue report and print clue log functions to their own files.
* Specifying the --devmode (-d) switch now tells radiolog to only display the PDFs rather than printing them. (You can always hit the print button yourself.)

== CONFIG STUFF
* Moved the SWITCHES object to app/logic/app_state.py so that source files other than radiolog.py can access them.
* We now have code that reads the new style config settings (into a common "CONFIG" namespace in the app.logic.app_state module). The old style config is still there (which reads local/radiolog.cfg into attributes of MyWindow.) The new style looks for local/radiolog.ini (INI not CFG). If it's there, it reads it into CONFIG. If the INI file is not there, then the settings that are loaded by the old style are simply copied over to CONFIG.

== 2WD STUFF
Extracted code dealing with making backup copies (into the 2WD) to file_management.py.

