### PR TITLE
fix #544

### DIFF
--- a/radiolog.py
+++ b/radiolog.py
@@ -1049,6 +1049,10 @@ class MyWindow(QDialog,Ui_Dialog):
 		self.teamTimer.timeout.connect(self.updateClock)
 		self.teamTimer.start(1000)
 
+		self.slowTimer=QTimer(self)
+		self.slowTimer.timeout.connect(self.saveRcIfNeeded)
+		self.slowTimer.start(5000)
+
 		self.fastTimer=QTimer(self)
 		self.fastTimer.timeout.connect(self.resizeRowsToContentsIfNeeded)
 		self.fastTimer.start(100)
@@ -3195,6 +3199,17 @@ class MyWindow(QDialog,Ui_Dialog):
 			out << "cleanShutdown=True\n"
 		rcFile.close()
 
+	def saveRcIfNeeded(self):
+		# this is probably cleaner, lighter, and more robust than using resizeEvent
+		(x,y,w,h)=self.geometry().getRect()
+		if x!=self.x or y!=self.y or w!=self.w or h!=self.h:
+			rprint('resize detected; saving rc file')
+			self.x=x
+			self.y=y
+			self.w=w
+			self.h=h
+			self.saveRcFile()
+		
 	def loadRcFile(self):
 		# this function gets called at startup (whether it's a clean fresh start
 		#  or an auto-recover) but timeout, datum, and coordFormat should only


### PR DESCRIPTION
The rc file only got saved at a few times during the flow; if there was a crash, a much-earlier window resize would never get saved.

Added a slow timer (every 5 seconds) to see if a resize has happened and save the rc file if so.

Note, the main dialog size still creeps upwards, because of the window decoration sizes (the border) but probably for other reasons too.

x/y/w/h in rc file immediately after crash:
28/415/1246/413

after restore:
29/422/1560/518