### PR TITLE
741 tracebacks nonetype object has no attribute layoutvisibleregionsetstylesheet

### DIFF
--- a/radiolog.py
+++ b/radiolog.py
@@ -8113,7 +8113,12 @@ class newEntryWidget(QWidget,Ui_newEntryWidget):
 
 	def updateTabLabel(self):
 		i=self.parent.newEntryWindow.ui.tabWidget.indexOf(self)
-		self.parent.newEntryWindow.ui.tabWidget.tabBar().tabButton(i,QTabBar.LeftSide).layout().itemAt(1).widget().setText(time.strftime("%H%M")+" "+self.ui.to_fromField.currentText()+" "+self.ui.teamField.text())
+		button=self.parent.newEntryWindow.ui.tabWidget.tabBar().tabButton(i,QTabBar.LeftSide)
+		newText=time.strftime("%H%M")+" "+self.ui.to_fromField.currentText()+" "+self.ui.teamField.text()
+		if button:
+			button.layout().itemAt(1).widget().setText(newText)
+		else:
+			rprint(' ERROR trying to updateTabLabel for a non-existent tab: i='+str(i)+'  newText='+str(newText))
 ##		self.parent.newEntryWindow.ui.tabWidget.tabBar().tabButton(i,QTabBar.LeftSide).setText(self.ui.teamField.text())
 ##		self.parent.newEntryWindow.ui.tabWidget.tabBar().tabButton(i,QTabBar.LeftSide).adjustSize()
 

--- a/radiolog.py
+++ b/radiolog.py
@@ -4831,8 +4831,16 @@ class MyWindow(QDialog,Ui_Dialog):
 			# NOTE the following line causes font-size to go back to system default;
 			#  can't figure out why it doesn't inherit font-size from the existing
 			#  styleSheet; so, each statusStyleDict entry must contain font-size explicitly
+			#741 - pass through in case the button is None; shouldn't ever happen due to other fixes fo #741
 			if not self.loadFlag:
-				self.ui.tabWidget.tabBar().tabButton(i,QTabBar.LeftSide).setStyleSheet(statusStyleDict[status])
+				button=self.ui.tabWidget.tabBar().tabButton(i,QTabBar.LeftSide)
+				if button:
+					button.setStyleSheet(statusStyleDict[status])
+				else:
+					rprint(' ERROR: there was an attempt to set the styleSheet for a non-existent tab button:')
+					rprint('   extTeamName='+str(extTeamName)+'  i='+str(i)+'  tabBar count='+str(self.ui.tabWidget.tabBar().count()))
+					rprint('   extTeamNameList='+str(self.extTeamNameList))
+					rprint(' Skipping this attempt')
 			# only reset the team timer if it is a 'FROM' message with non-blank message text
 			#  (prevent reset on amend, where to_from can be "AMEND" and msg can be anything)
 			# if this was an amendment, set team timer based on the team's most recent 'FROM' entry


### PR DESCRIPTION
fix #741 
NOTE that the only tangible changes here were:

- always call rebuildTabs when unhiding a hidden team tab
- don't always clear the tabWidget only based on length of extTeamNameList; only clear of length=0 or if all elements contain 'spacer'

The other 'fixes' are just check-and-message clauses, but, the team tab issues should hopefully never be triggered due to changes above.  The cause for the NEW finger tab issue isn't clear, but, added a check-and-message clause there too.