### PR TITLE
fix #750

### DIFF
--- a/radiolog.py
+++ b/radiolog.py
@@ -2534,6 +2534,11 @@ class MyWindow(QDialog,Ui_Dialog):
 						except:
 							pass
 					break # to preserve 'widget' variable for use below
+		#750 reset team timer here, regardless of whether a new entry is opened
+		#  but only if the the team's timer already exists, to prevent error in updateTeamTimers
+		extTeamName=getExtTeamName(callsign)
+		if extTeamName in teamTimersDict:
+			teamTimersDict[extTeamName]=0
 		if fleet and dev:
 			fsResult=found # False or 'continue' or 'child'
 			resultSuffix=''


### PR DESCRIPTION
For incoming FS or NXDN, the callsign's timer (if it is already being timed) will be reset to 0, on BOT and again on EOT.

As a reminder of existing behavior: For non-FS/NXDN, the callsign's timer is reset only when the entry is saved.
